### PR TITLE
Included webpack_config_path in test scripts.

### DIFF
--- a/packages/terra-clinical-detail-view/package.json
+++ b/packages/terra-clinical-detail-view/package.json
@@ -48,11 +48,11 @@
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",
-    "test:nightwatch-default": "SPECTRE_TEST_SUITE=terra-clinical-detail-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js",
-    "test:nightwatch-chrome": "SPECTRE_TEST_SUITE=terra-clinical-detail-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js chrome",
-    "test:nightwatch-firefox": "SPECTRE_TEST_SUITE=terra-clinical-detail-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js firefox",
-    "test:nightwatch-safari": "SPECTRE_TEST_SUITE=terra-clinical-detail-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari",
-    "test:remote": "REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js",
-    "test:remote:all": "REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js --env chrome-tiny,chrome-small,chrome-medium,chrome-large,chrome-huge,chrome-enormous,firefox-tiny,firefox-small,firefox-medium,firefox-large,firefox-huge,firefox-enormous,ie10-tiny,ie10-small,ie10-medium,ie10-large,ie10-huge,ie10-enormous,ie11-tiny,ie11-small,ie11-medium,ie11-large,ie11-huge,ie11-enormous,edge-tiny,edge-small,edge-medium,edge-large,edge-huge,edge-enormous,safari-tiny,safari-small,safari-medium,safari-large,safari-huge,safari-enormous"
+    "test:nightwatch-default": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=terra-clinical-detail-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js",
+    "test:nightwatch-chrome": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=terra-clinical-detail-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js chrome",
+    "test:nightwatch-firefox": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=terra-clinical-detail-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js firefox",
+    "test:nightwatch-safari": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=terra-clinical-detail-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari",
+    "test:remote": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js",
+    "test:remote:all": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js --env chrome-tiny,chrome-small,chrome-medium,chrome-large,chrome-huge,chrome-enormous,firefox-tiny,firefox-small,firefox-medium,firefox-large,firefox-huge,firefox-enormous,ie10-tiny,ie10-small,ie10-medium,ie10-large,ie10-huge,ie10-enormous,ie11-tiny,ie11-small,ie11-medium,ie11-large,ie11-huge,ie11-enormous,edge-tiny,edge-small,edge-medium,edge-large,edge-huge,edge-enormous,safari-tiny,safari-small,safari-medium,safari-large,safari-huge,safari-enormous"
   }
 }

--- a/packages/terra-clinical-item-view/package.json
+++ b/packages/terra-clinical-item-view/package.json
@@ -49,11 +49,11 @@
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",
-    "test:nightwatch-default": "SPECTRE_TEST_SUITE=terra-clinical-item-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js",
-    "test:nightwatch-chrome": "SPECTRE_TEST_SUITE=terra-clinical-item-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js chrome",
-    "test:nightwatch-firefox": "SPECTRE_TEST_SUITE=terra-clinical-item-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js firefox",
-    "test:nightwatch-safari": "SPECTRE_TEST_SUITE=terra-clinical-item-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari",
-    "test:remote": "REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js",
-    "test:remote:all": "REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js --env chrome-tiny,chrome-small,chrome-medium,chrome-large,chrome-huge,chrome-enormous,firefox-tiny,firefox-small,firefox-medium,firefox-large,firefox-huge,firefox-enormous,ie10-tiny,ie10-small,ie10-medium,ie10-large,ie10-huge,ie10-enormous,ie11-tiny,ie11-small,ie11-medium,ie11-large,ie11-huge,ie11-enormous,edge-tiny,edge-small,edge-medium,edge-large,edge-huge,edge-enormous,safari-tiny,safari-small,safari-medium,safari-large,safari-huge,safari-enormous"
+    "test:nightwatch-default": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=terra-clinical-item-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js",
+    "test:nightwatch-chrome": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=terra-clinical-item-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js chrome",
+    "test:nightwatch-firefox": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=terra-clinical-item-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js firefox",
+    "test:nightwatch-safari": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=terra-clinical-item-view node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari",
+    "test:remote": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js",
+    "test:remote:all": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js --env chrome-tiny,chrome-small,chrome-medium,chrome-large,chrome-huge,chrome-enormous,firefox-tiny,firefox-small,firefox-medium,firefox-large,firefox-huge,firefox-enormous,ie10-tiny,ie10-small,ie10-medium,ie10-large,ie10-huge,ie10-enormous,ie11-tiny,ie11-small,ie11-medium,ie11-large,ie11-huge,ie11-enormous,edge-tiny,edge-small,edge-medium,edge-large,edge-huge,edge-enormous,safari-tiny,safari-small,safari-medium,safari-large,safari-huge,safari-enormous"
   }
 }


### PR DESCRIPTION
### Summary
Specified the webpack_config_path for each nightwatch test script. Addresses issue #9. 

### Additional Details
All new packages will need to include `WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config` in the test scripts for nightwatch tests to run on a package level. 

