### PR TITLE
Execute Jest tests concurrently.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pretest": "npm run lint",
     "postinstall": "npm run bootstrap",
     "start": "cd packages/terra-clinical-site && npm run start",
-    "test": "lerna exec --concurrency 1 npm run test:spec && npm run test:nightwatch-default",
+    "test": "jest && npm run test:nightwatch-default",
     "test:nightwatch-default": "WEBPACK_CONFIG_PATH=../../../packages/terra-clinical-site/webpack.config node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --env default-tiny,default-small,default-medium,default-large,default-huge,default-enormous"
   },
   "devDependencies": {


### PR DESCRIPTION
### Summary
Jest tests now run concurrently instead of one package at a time. Addresses issue #10.

@cerner/terra