### PR TITLE
Do not add flex item for accessory section is the accessory isn't pre…

### DIFF
--- a/packages/terra-clinical-item-view/lib/ItemView.js
+++ b/packages/terra-clinical-item-view/lib/ItemView.js
@@ -127,11 +127,15 @@ var ItemView = function (_React$Component) {
   }], [{
     key: 'renderAccessory',
     value: function renderAccessory(accessory) {
-      return _react2.default.createElement(
-        'div',
-        { className: 'terraClinical-ItemView-accessory' },
-        accessory
-      );
+      var accessorySection = void 0;
+      if (accessory) {
+        accessorySection = _react2.default.createElement(
+          'div',
+          { className: 'terraClinical-ItemView-accessory' },
+          accessory
+        );
+      }
+      return accessorySection;
     }
   }, {
     key: 'renderRows',

--- a/packages/terra-clinical-item-view/lib/ItemView.js
+++ b/packages/terra-clinical-item-view/lib/ItemView.js
@@ -109,29 +109,31 @@ var ItemView = function (_React$Component) {
           comment = _props.comment,
           customProps = _objectWithoutProperties(_props, ['layout', 'textEmphasis', 'isTruncated', 'accessoryAlignment', 'startAccessory', 'endAccessory', 'displays', 'comment']);
 
-      var viewClassNames = (0, _classnames2.default)(['terraClinical-ItemView', { 'terraClinical-ItemView--isTruncated': isTruncated }, _defineProperty({}, 'terraClinical-ItemView--' + layout, layout), _defineProperty({}, 'terraClinical-ItemView-accessory--' + accessoryAlignment, accessoryAlignment), customProps.className]);
+      var viewClassNames = (0, _classnames2.default)(['terraClinical-ItemView', { 'terraClinical-ItemView--isTruncated': isTruncated }, _defineProperty({}, 'terraClinical-ItemView--' + layout, layout), customProps.className]);
 
       return _react2.default.createElement(
         'div',
         _extends({}, customProps, { className: viewClassNames }),
-        ItemView.renderAccessory(startAccessory),
+        ItemView.renderAccessory(startAccessory, accessoryAlignment),
         _react2.default.createElement(
           'div',
           { className: 'terraClinical-ItemView-body' },
           ItemView.renderRows(displays, layout, textEmphasis),
           comment
         ),
-        ItemView.renderAccessory(endAccessory)
+        ItemView.renderAccessory(endAccessory, accessoryAlignment)
       );
     }
   }], [{
     key: 'renderAccessory',
-    value: function renderAccessory(accessory) {
+    value: function renderAccessory(accessory, accessoryAlignment) {
+      var accessoryClassNames = (0, _classnames2.default)(['terraClinical-ItemView-accessory', _defineProperty({}, 'terraClinical-ItemView-accessory--' + accessoryAlignment, accessoryAlignment)]);
+
       var accessorySection = void 0;
       if (accessory) {
         accessorySection = _react2.default.createElement(
           'div',
-          { className: 'terraClinical-ItemView-accessory' },
+          { className: accessoryClassNames },
           accessory
         );
       }

--- a/packages/terra-clinical-item-view/lib/ItemView.scss
+++ b/packages/terra-clinical-item-view/lib/ItemView.scss
@@ -28,11 +28,11 @@
 }
 
 .terraClinical-ItemView-accessory--alignTop {
-  align-items: flex-start;
+  align-self: flex-start;
 }
 
 .terraClinical-ItemView-accessory--alignCenter {
-  align-items: center;
+  align-self: center;
 }
 
 // Content Layout

--- a/packages/terra-clinical-item-view/src/ItemView.jsx
+++ b/packages/terra-clinical-item-view/src/ItemView.jsx
@@ -53,11 +53,16 @@ const defaultProps = {
 
 class ItemView extends React.Component {
 
-  static renderAccessory(accessory) {
+  static renderAccessory(accessory, accessoryAlignment) {
+    const accessoryClassNames = classNames([
+      'terraClinical-ItemView-accessory',
+      { [`terraClinical-ItemView-accessory--${accessoryAlignment}`]: accessoryAlignment },
+    ]);
+
     let accessorySection;
     if (accessory) {
       accessorySection = (
-        <div className="terraClinical-ItemView-accessory">
+        <div className={accessoryClassNames}>
           {accessory}
         </div>
       );
@@ -158,18 +163,17 @@ class ItemView extends React.Component {
       'terraClinical-ItemView',
       { 'terraClinical-ItemView--isTruncated': isTruncated },
       { [`terraClinical-ItemView--${layout}`]: layout },
-      { [`terraClinical-ItemView-accessory--${accessoryAlignment}`]: accessoryAlignment },
       customProps.className,
     ]);
 
     return (
       <div {...customProps} className={viewClassNames}>
-        {ItemView.renderAccessory(startAccessory)}
+        {ItemView.renderAccessory(startAccessory, accessoryAlignment)}
         <div className="terraClinical-ItemView-body">
           {ItemView.renderRows(displays, layout, textEmphasis)}
           {comment}
         </div>
-        {ItemView.renderAccessory(endAccessory)}
+        {ItemView.renderAccessory(endAccessory, accessoryAlignment)}
       </div>
     );
   }

--- a/packages/terra-clinical-item-view/src/ItemView.jsx
+++ b/packages/terra-clinical-item-view/src/ItemView.jsx
@@ -54,11 +54,15 @@ const defaultProps = {
 class ItemView extends React.Component {
 
   static renderAccessory(accessory) {
-    return (
-      <div className="terraClinical-ItemView-accessory">
-        {accessory}
-      </div>
-    );
+    let accessorySection;
+    if (accessory) {
+      accessorySection = (
+        <div className="terraClinical-ItemView-accessory">
+          {accessory}
+        </div>
+      );
+    }
+    return accessorySection;
   }
 
   static renderRows(displays, layout, emphasis) {

--- a/packages/terra-clinical-item-view/src/ItemView.scss
+++ b/packages/terra-clinical-item-view/src/ItemView.scss
@@ -28,11 +28,11 @@
 }
 
 .terraClinical-ItemView-accessory--alignTop {
-  align-items: flex-start;
+  align-self: flex-start;
 }
 
 .terraClinical-ItemView-accessory--alignCenter {
-  align-items: center;
+  align-self: center;
 }
 
 // Content Layout

--- a/packages/terra-clinical-item-view/tests/jest/__snapshots__/ItemView.test.jsx.snap
+++ b/packages/terra-clinical-item-view/tests/jest/__snapshots__/ItemView.test.jsx.snap
@@ -2,8 +2,6 @@ exports[`test should render 1 start theme display 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
   <div
-    className="terraClinical-ItemView-accessory" />
-  <div
     className="terraClinical-ItemView-body">
     <div
       className="terraClinical-ItemView-rowContainer">
@@ -18,16 +16,12 @@ exports[`test should render 1 start theme display 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render 2 start theme displays 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -52,16 +46,12 @@ exports[`test should render 2 start theme displays 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render 3 start theme displays 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -95,16 +85,12 @@ exports[`test should render 3 start theme displays 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render a comment 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body">
     <Comment
@@ -113,8 +99,6 @@ exports[`test should render a comment 1`] = `
       text="comment"
       textStyle="attention" />
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
@@ -122,19 +106,13 @@ exports[`test should render a default component 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
   <div
-    className="terraClinical-ItemView-accessory" />
-  <div
     className="terraClinical-ItemView-body" />
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render a end accessory 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body" />
   <div
@@ -155,8 +133,6 @@ exports[`test should render a start accessory 1`] = `
   </div>
   <div
     className="terraClinical-ItemView-body" />
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
@@ -170,8 +146,6 @@ exports[`test should render an accessory center aligned 1`] = `
   </div>
   <div
     className="terraClinical-ItemView-body" />
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
@@ -185,16 +159,12 @@ exports[`test should render an accessory top aligned 1`] = `
   </div>
   <div
     className="terraClinical-ItemView-body" />
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render one column 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -219,16 +189,12 @@ exports[`test should render one column 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render truncated display 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -244,16 +210,12 @@ exports[`test should render truncated display 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render two columns with 8 displays 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--twoColumns terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -320,16 +282,12 @@ exports[`test should render two columns with 8 displays 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render two columns with odd number of displays 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--twoColumns terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -360,16 +318,12 @@ exports[`test should render two columns with odd number of displays 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render with 1 display 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -385,16 +339,12 @@ exports[`test should render with 1 display 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render with 2 displays 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -419,16 +369,12 @@ exports[`test should render with 2 displays 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render with 3 displays 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -462,16 +408,12 @@ exports[`test should render with 3 displays 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;
 
 exports[`test should render with a display and graphic 1`] = `
 <div
   className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
-  <div
-    className="terraClinical-ItemView-accessory" />
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -491,7 +433,5 @@ exports[`test should render with a display and graphic 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="terraClinical-ItemView-accessory" />
 </div>
 `;

--- a/packages/terra-clinical-item-view/tests/jest/__snapshots__/ItemView.test.jsx.snap
+++ b/packages/terra-clinical-item-view/tests/jest/__snapshots__/ItemView.test.jsx.snap
@@ -1,6 +1,6 @@
 exports[`test should render 1 start theme display 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -21,7 +21,7 @@ exports[`test should render 1 start theme display 1`] = `
 
 exports[`test should render 2 start theme displays 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -51,7 +51,7 @@ exports[`test should render 2 start theme displays 1`] = `
 
 exports[`test should render 3 start theme displays 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -90,7 +90,7 @@ exports[`test should render 3 start theme displays 1`] = `
 
 exports[`test should render a comment 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body">
     <Comment
@@ -104,7 +104,7 @@ exports[`test should render a comment 1`] = `
 
 exports[`test should render a default component 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body" />
 </div>
@@ -112,11 +112,11 @@ exports[`test should render a default component 1`] = `
 
 exports[`test should render a end accessory 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body" />
   <div
-    className="terraClinical-ItemView-accessory">
+    className="terraClinical-ItemView-accessory terraClinical-ItemView-accessory--alignCenter">
     <img
       alt="Graphic" />
   </div>
@@ -125,9 +125,9 @@ exports[`test should render a end accessory 1`] = `
 
 exports[`test should render a start accessory 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
-    className="terraClinical-ItemView-accessory">
+    className="terraClinical-ItemView-accessory terraClinical-ItemView-accessory--alignCenter">
     <img
       alt="Graphic" />
   </div>
@@ -138,9 +138,9 @@ exports[`test should render a start accessory 1`] = `
 
 exports[`test should render an accessory center aligned 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
-    className="terraClinical-ItemView-accessory">
+    className="terraClinical-ItemView-accessory terraClinical-ItemView-accessory--alignCenter">
     <img
       alt="Graphic" />
   </div>
@@ -151,9 +151,9 @@ exports[`test should render an accessory center aligned 1`] = `
 
 exports[`test should render an accessory top aligned 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignTop">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
-    className="terraClinical-ItemView-accessory">
+    className="terraClinical-ItemView-accessory terraClinical-ItemView-accessory--alignTop">
     <img
       alt="Graphic" />
   </div>
@@ -164,7 +164,7 @@ exports[`test should render an accessory top aligned 1`] = `
 
 exports[`test should render one column 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -194,7 +194,7 @@ exports[`test should render one column 1`] = `
 
 exports[`test should render truncated display 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -215,7 +215,7 @@ exports[`test should render truncated display 1`] = `
 
 exports[`test should render two columns with 8 displays 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--twoColumns terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--twoColumns">
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -287,7 +287,7 @@ exports[`test should render two columns with 8 displays 1`] = `
 
 exports[`test should render two columns with odd number of displays 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--twoColumns terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--twoColumns">
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -323,7 +323,7 @@ exports[`test should render two columns with odd number of displays 1`] = `
 
 exports[`test should render with 1 display 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -344,7 +344,7 @@ exports[`test should render with 1 display 1`] = `
 
 exports[`test should render with 2 displays 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -374,7 +374,7 @@ exports[`test should render with 2 displays 1`] = `
 
 exports[`test should render with 3 displays 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body">
     <div
@@ -413,7 +413,7 @@ exports[`test should render with 3 displays 1`] = `
 
 exports[`test should render with a display and graphic 1`] = `
 <div
-  className="terraClinical-ItemView terraClinical-ItemView--oneColumn terraClinical-ItemView-accessory--alignCenter">
+  className="terraClinical-ItemView terraClinical-ItemView--oneColumn">
   <div
     className="terraClinical-ItemView-body">
     <div

--- a/packages/terra-clinical-item-view/tests/nightwatch/item-view/item-view-spec.js
+++ b/packages/terra-clinical-item-view/tests/nightwatch/item-view/item-view-spec.js
@@ -43,7 +43,8 @@ module.exports = {
     browser.expect.element('#test-end-accessory .terraClinical-ItemView-accessory:nth-child(2) > :first-child').to.be.present;
     browser.expect.element('#test-both-accessory-top .terraClinical-ItemView-accessory:nth-child(1) > :first-child').to.be.present;
     browser.expect.element('#test-both-accessory-top .terraClinical-ItemView-accessory:nth-child(3) > :first-child').to.be.present;
-    browser.assert.cssClassPresent('#test-both-accessory-top', 'terraClinical-ItemView-accessory--alignTop');
+    browser.assert.cssClassPresent('#test-both-accessory-top .terraClinical-ItemView-accessory:nth-child(1)', 'terraClinical-ItemView-accessory--alignTop');
+    browser.assert.cssClassPresent('#test-both-accessory-top .terraClinical-ItemView-accessory:nth-child(3)', 'terraClinical-ItemView-accessory--alignTop');
   },
   'Displays a clinical item view with a comment set': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/item-view-tests/comment`);

--- a/packages/terra-clinical-item-view/tests/nightwatch/item-view/item-view-spec.js
+++ b/packages/terra-clinical-item-view/tests/nightwatch/item-view/item-view-spec.js
@@ -38,9 +38,9 @@ module.exports = {
   'Displays a clinical item view with accessories set': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/item-view-tests/accessory`);
     browser.expect.element('#test-start-accessory .terraClinical-ItemView-accessory:nth-child(1) > :first-child').to.be.present;
-    browser.expect.element('#test-start-accessory .terraClinical-ItemView-accessory:nth-child(3) > :first-child').to.not.be.present;
+    browser.expect.element('#test-start-accessory .terraClinical-ItemView-accessory:nth-child(2) > :first-child').to.not.be.present;
     browser.expect.element('#test-end-accessory .terraClinical-ItemView-accessory:nth-child(1) > :first-child').to.not.be.present;
-    browser.expect.element('#test-end-accessory .terraClinical-ItemView-accessory:nth-child(3) > :first-child').to.be.present;
+    browser.expect.element('#test-end-accessory .terraClinical-ItemView-accessory:nth-child(2) > :first-child').to.be.present;
     browser.expect.element('#test-both-accessory-top .terraClinical-ItemView-accessory:nth-child(1) > :first-child').to.be.present;
     browser.expect.element('#test-both-accessory-top .terraClinical-ItemView-accessory:nth-child(3) > :first-child').to.be.present;
     browser.assert.cssClassPresent('#test-both-accessory-top', 'terraClinical-ItemView-accessory--alignTop');

--- a/packages/terra-clinical-site/package.json
+++ b/packages/terra-clinical-site/package.json
@@ -35,6 +35,7 @@
     "terra-clinical-error-view": "^0.x",
     "terra-clinical-label-value-view": "^0.x",
     "terra-clinical-no-data-view": "^0.x",
+    "terra-icon": "^0.x",
     "terra-grid": "^2.x",
     "terra-legacy-theme": "^0.x",
     "terra-markdown": "^0.x",

--- a/packages/terra-clinical-site/src/examples/item-view/Index.jsx
+++ b/packages/terra-clinical-site/src/examples/item-view/Index.jsx
@@ -15,6 +15,7 @@ import ItemViewTwoColumn from './ItemViewTwoColumn';
 import ItemViewTwoColumnStart from './ItemViewTwoColumnStart';
 import ItemViewComment from './ItemViewComment';
 import ItemViewAll from './ItemViewAll';
+import ItemViewAllTopAligned from './ItemViewAllTopAligned';
 
 const ItemViewExamples = () => (
   <div>
@@ -31,6 +32,8 @@ const ItemViewExamples = () => (
     <ItemViewComment />
     <h2 id="all-elements">All Elements ItemView</h2>
     <ItemViewAll />
+    <h2 id="all-elements-top">All Elements ItemView Top Aligned</h2>
+    <ItemViewAllTopAligned />
   </div>
 );
 

--- a/packages/terra-clinical-site/src/examples/item-view/ItemViewAllTopAligned.jsx
+++ b/packages/terra-clinical-site/src/examples/item-view/ItemViewAllTopAligned.jsx
@@ -22,6 +22,7 @@ export default () => <ItemView
   layout="twoColumns"
   isTruncated
   textEmphasis="start"
+  accessoryAlignment="alignTop"
   startAccessory={accessoryStart}
   endAccessory={accessoryEnd}
   comment={comment}


### PR DESCRIPTION
Summary:
Do not add the empty div for accessories if the accessory element is not present. This prevents the unneeded margin from being added to the item view and throwing off alignment.

Addresses #29 