### PR TITLE
Fix Label Value View Test Route

### DIFF
--- a/packages/terra-clinical-label-value-view/tests/nightwatch/LabelValueViewTests.jsx
+++ b/packages/terra-clinical-label-value-view/tests/nightwatch/LabelValueViewTests.jsx
@@ -8,7 +8,7 @@ const LabelValueViewTests = () => (
     <ul>
       <li><Link to="/tests/label-value-view-tests/default">Default LabelValueView</Link></li>
       <li><Link to="/tests/label-value-view-tests/text-value">LabelValueView with a Text Input</Link></li>
-      <li><Link to="/tests/label-value-view-tests/node-value">LabelValueView with an Node Input</Link></li>
+      <li><Link to="/tests/label-value-view-tests/element-value">LabelValueView with an Node Input</Link></li>
       <li><Link to="/tests/label-value-view-tests/multiple-values">LabelValueView with Text and Node Inputs</Link></li>
     </ul>
   </div>


### PR DESCRIPTION
The link `LabelValueView with a Node Input` was incorrect and resulted in no example being loaded. Fixed to display the example on the site.

@cerner/terra

