### PR TITLE
fix error display spacing, fix padding on glyph in error and no data,…

### DIFF
--- a/packages/terra-clinical-error-view/lib/ErrorView.js
+++ b/packages/terra-clinical-error-view/lib/ErrorView.js
@@ -87,10 +87,14 @@ var ErrorView = function ErrorView(_ref) {
 
   var nameSection = void 0;
   if (name) {
+    var nameDisplay = name;
+    if (name && description) {
+      nameDisplay += '.  ';
+    }
     nameSection = _react2.default.createElement(
       'b',
       { className: 'terraClinical-ErrorView-name' },
-      name
+      nameDisplay
     );
   }
 

--- a/packages/terra-clinical-error-view/lib/ErrorView.scss
+++ b/packages/terra-clinical-error-view/lib/ErrorView.scss
@@ -4,13 +4,14 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  padding: 2.857rem 0 1.429rem;
+  padding: 1.429rem 0;
   width: 100%;
 }
 
 .terraClinical-ErrorView-glyph {
   flex: 0 0 auto;
   padding-bottom: 0.2857rem;
+  padding-top: 1.429rem;
 }
 
 .terraClinical-ErrorView-text {

--- a/packages/terra-clinical-error-view/src/ErrorView.jsx
+++ b/packages/terra-clinical-error-view/src/ErrorView.jsx
@@ -58,7 +58,11 @@ const ErrorView = ({
 
   let nameSection;
   if (name) {
-    nameSection = <b className="terraClinical-ErrorView-name">{name}</b>;
+    let nameDisplay = name;
+    if (name && description) {
+      nameDisplay += '.  ';
+    }
+    nameSection = <b className="terraClinical-ErrorView-name">{nameDisplay}</b>;
   }
 
   let buttonSection;

--- a/packages/terra-clinical-error-view/src/ErrorView.scss
+++ b/packages/terra-clinical-error-view/src/ErrorView.scss
@@ -4,13 +4,14 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  padding: 2.857rem 0 1.429rem;
+  padding: 1.429rem 0;
   width: 100%;
 }
 
 .terraClinical-ErrorView-glyph {
   flex: 0 0 auto;
   padding-bottom: 0.2857rem;
+  padding-top: 1.429rem;
 }
 
 .terraClinical-ErrorView-text {

--- a/packages/terra-clinical-item-display/lib/ItemDisplay.scss
+++ b/packages/terra-clinical-item-display/lib/ItemDisplay.scss
@@ -18,10 +18,13 @@
   height: 20px;
   max-width: 20px;
   overflow: hidden;
+  position: relative;
 }
 
 .terraClinical-ItemDisplay-inlineIcon > * {
   font-size: 1rem;
+  height: 20px;
+  width: 16px;
 }
 
 .terraClinical-ItemDisplay-text,

--- a/packages/terra-clinical-item-display/src/ItemDisplay.scss
+++ b/packages/terra-clinical-item-display/src/ItemDisplay.scss
@@ -18,10 +18,13 @@
   height: 20px;
   max-width: 20px;
   overflow: hidden;
+  position: relative;
 }
 
 .terraClinical-ItemDisplay-inlineIcon > * {
   font-size: 1rem;
+  height: 20px;
+  width: 16px;
 }
 
 .terraClinical-ItemDisplay-text,

--- a/packages/terra-clinical-no-data-view/lib/NoDataView.scss
+++ b/packages/terra-clinical-no-data-view/lib/NoDataView.scss
@@ -4,13 +4,14 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  padding: 2.857rem 0 1.429rem;
+  padding: 1.429rem 0;
   width: 100%;
 }
 
 .terraClinical-NoDataView-glyph {
   flex: 0 0 auto;
   padding-bottom: 0.2857rem;
+  padding-top: 1.429rem;
 }
 
 .terraClinical-NoDataView-heading {

--- a/packages/terra-clinical-no-data-view/src/NoDataView.scss
+++ b/packages/terra-clinical-no-data-view/src/NoDataView.scss
@@ -4,13 +4,14 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  padding: 2.857rem 0 1.429rem;
+  padding: 1.429rem 0;
   width: 100%;
 }
 
 .terraClinical-NoDataView-glyph {
   flex: 0 0 auto;
   padding-bottom: 0.2857rem;
+  padding-top: 1.429rem;
 }
 
 .terraClinical-NoDataView-heading {

--- a/packages/terra-clinical-site/src/examples/error-view/ErrorViewHiddenGlyphNoButton.jsx
+++ b/packages/terra-clinical-site/src/examples/error-view/ErrorViewHiddenGlyphNoButton.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import ErrorView from 'terra-clinical-error-view';
+
+const view = () => (
+  <ErrorView
+    name="test name"
+    description="test description"
+    isGlyphHidden
+  />);
+
+export default view;

--- a/packages/terra-clinical-site/src/examples/error-view/ErrorViewNoDescription.jsx
+++ b/packages/terra-clinical-site/src/examples/error-view/ErrorViewNoDescription.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import ErrorView from 'terra-clinical-error-view';
+
+const view = () => (
+  <ErrorView
+    name="test name"
+    buttonText="test button"
+    isGlyphHidden={false}
+  />);
+
+export default view;

--- a/packages/terra-clinical-site/src/examples/error-view/ErrorViewNoName.jsx
+++ b/packages/terra-clinical-site/src/examples/error-view/ErrorViewNoName.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import ErrorView from 'terra-clinical-error-view';
+
+const view = () => (
+  <ErrorView
+    description="test description"
+    buttonText="test button"
+    isGlyphHidden={false}
+  />);
+
+export default view;

--- a/packages/terra-clinical-site/src/examples/error-view/Index.jsx
+++ b/packages/terra-clinical-site/src/examples/error-view/Index.jsx
@@ -12,6 +12,9 @@ import ErrorViewSrc from '!raw-loader!terra-clinical-error-view/src/ErrorView.js
 // Example Files
 import ErrorViewStandard from './ErrorViewStandard';
 import ErrorViewHiddenGlyph from './ErrorViewHiddenGlyph';
+import ErrorViewHiddenGlyphNoButton from './ErrorViewHiddenGlyphNoButton';
+import ErrorViewNoName from './ErrorViewNoName';
+import ErrorViewNoDescription from './ErrorViewNoDescription';
 
 const ErrorViewExamples = () => (
   <div>
@@ -22,6 +25,12 @@ const ErrorViewExamples = () => (
     <ErrorViewStandard />
     <h2 id="errorView-glyph-hidden">Error View With Glyph Hidden</h2>
     <ErrorViewHiddenGlyph />
+    <h2 id="errorView-glyph-hidden-no-button">Error View With Glyph Hidden and No Button</h2>
+    <ErrorViewHiddenGlyphNoButton />
+    <h2 id="errorView-no-name">Error View With No Name</h2>
+    <ErrorViewNoName />
+    <h2 id="errorView-no-description">Error View No Description</h2>
+    <ErrorViewNoDescription />
   </div>
 );
 


### PR DESCRIPTION
Fixes #55 

Adjust padding on no-data and error views to allow for 20 padding-top when the glyph isn't present

Set sizing on icons within the item-display to correct scale across all browsers.

Add a period and spacing between the error name and description.