### PR TITLE
Heroku configuration & scripts. Express scripts.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run start:express

--- a/app.json
+++ b/app.json
@@ -1,0 +1,34 @@
+{
+  "name": "terra-clinical",
+  "description": "Heroku reviews app for terra-clinical development",
+  "keywords": [
+    "productivity"
+  ],
+  "website": "https://engineering.cerner.com/terra-clinical/#/site",
+  "repository": "https://github.com/cerner/terra-clinical",
+  "success_url": "/",
+  "scripts": {},
+  "env": {
+    "NODE_ENV": {
+      "description": "development environment",
+      "value": "development"
+    },
+    "NPM_CONFIG_PRODUCTION": {
+      "description": "development environment",
+      "value": "false"
+    },
+    "NODE_MODULES_CACHE": {
+      "description": "No cache",
+      "value": "false"
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "free"
+    }
+  },
+  "stack": "heroku-16",
+  "addons": [],
+  "buildpacks": []
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "description": "terra-clinical",
+  "engines": {
+    "node": "6.9.4"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cerner/terra-clinical.git"
@@ -39,7 +42,10 @@
     "clean:install": "npm run clean:all && npm install",
     "clean:obsolete-snapshots": "npm test -- -u",
     "compile": "lerna run compile",
+    "compile:heroku": "cd packages/terra-clinical-site && npm run compile:heroku",
     "deploy": "lerna run --scope terra-clinical-site deploy",
+    "heroku-prebuild": "npm install -g lerna@2.0.0-rc.4",
+    "heroku-postbuild": "npm install --only=dev && npm run compile:heroku",
     "jest": "jest",
     "jest:coverage": "jest --coverage",
     "lint": "npm run lint:js && npm run lint:scss",
@@ -49,6 +55,7 @@
     "pretest": "npm run lint",
     "postinstall": "npm run bootstrap",
     "start": "cd packages/terra-clinical-site && npm run start",
+    "start:express": "node scripts/express/app.js",
     "test": "jest && npm run test:nightwatch-default",
     "test:nightwatch-default": "WEBPACK_CONFIG_PATH=../../../packages/terra-clinical-site/webpack.config node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --env default-tiny,default-small,default-medium,default-large,default-huge,default-enormous"
   },
@@ -67,6 +74,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.9.0",
+    "express": "^4.15.2",
     "glob": "^7.1.1",
     "husky": "^0.13.3",
     "identity-obj-proxy": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "compile": "lerna run compile",
     "compile:heroku": "cd packages/terra-clinical-site && npm run compile:heroku",
     "deploy": "lerna run --scope terra-clinical-site deploy",
-    "heroku-prebuild": "npm install -g lerna@2.0.0-rc.4",
+    "heroku-prebuild": "npm install -g lerna@2.0.0-rc.4 && lerna init",
     "heroku-postbuild": "npm install --only=dev && npm run compile:heroku",
     "jest": "jest",
     "jest:coverage": "jest --coverage",

--- a/packages/terra-clinical-site/package.json
+++ b/packages/terra-clinical-site/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/cerner/terra-clinical#readme",
   "scripts": {
     "start": "webpack-dev-server --progress",
+    "compile:heroku": "webpack --config webpack.prod.config --progress",
     "compile:prod": "webpack --config webpack.prod.config -p",
     "compile:prod-stats": "webpack --config webpack.prod.config -p --json > stats.json",
     "deploy": "npm run compile:prod && gh-pages -d build",

--- a/packages/terra-clinical-site/webpack.config.js
+++ b/packages/terra-clinical-site/webpack.config.js
@@ -85,6 +85,7 @@ module.exports = {
   devtool: 'cheap-source-map',
   devServer: {
     host: '0.0.0.0',
+    disableHostcheck: true,
     stats: {
       assert: true,
       children: false,

--- a/scripts/express/README.md
+++ b/scripts/express/README.md
@@ -1,0 +1,11 @@
+#start:express
+
+The start:express script will automatically run on Heroku reviews app pipeline or it can manually be executed using the command below:
+
+```
+npm run compile:heroku
+npm run start:express
+```
+
+The start:express script will:
+* Start an express server to serve all built static assets by webpack

--- a/scripts/express/app.js
+++ b/scripts/express/app.js
@@ -1,0 +1,15 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-console */
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const port = process.env.PORT || 8081;
+// path to webpack built path
+const buildPath = path.join(__dirname, '../../packages/terra-clinical-site/build');
+
+app.use('/static', express.static(buildPath));
+app.get('/', (req, res) => res.redirect('/static'));
+app.listen(port);
+console.log(`Listening ${port}`);
+console.log(`Production Environment: ${process.env.NODE_ENV === 'production'}`);


### PR DESCRIPTION
### Summary
A heroku application and pipeline was created for terra-clinical. Addresses issue #57. 

The changes in this pull request are:
1. Add `app.json` for heroku app.
2. Add `scripts/express` for express server.
3. Update `package.json` to add express and heroku scripts.
4. Update `terra-clincial-site/package.json` to add heroku script.
4. Add config to `webpack.config.js` to disable host check from webpack-dev-server.
5. Add `Procfile` to specify heroku server command

These changes reflect changes made [here](https://github.com/cerner/terra-core/pull/318) and [here](https://github.com/cerner/terra-core/pull/326).

@cerner/terra