### PR TITLE
Fix Configurations

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -4,9 +4,9 @@ const path = require('path');
 const fs = require('fs');
 const loadJsonFile = require('load-json-file');
 const globSync = require('glob').sync;
-const testSettings = require('./node_modules/terra-toolkit/lib/index').testSettings;
+const testSettings = require('terra-toolkit/lib/index').testSettings;
 const resolve = require('path').resolve;
-const nightwatchConfiguration = require('./node_modules/terra-toolkit/lib/nightwatch.json');
+const nightwatchConfiguration = require('terra-toolkit/lib/nightwatch.json');
 
 module.exports = ((settings) => {
   const updatedSettings = testSettings(resolve('./packages/terra-clinical-site/webpack.config'), settings);

--- a/packages/terra-clinical-action-header/tests/nightwatch.conf.js
+++ b/packages/terra-clinical-action-header/tests/nightwatch.conf.js
@@ -1,8 +1,8 @@
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 
-const testSettings = require('../node_modules/terra-toolkit').testSettings;
+const testSettings = require('terra-toolkit').testSettings;
 const resolve = require('path').resolve;
-const nightwatchConfiguration = require('../node_modules/terra-toolkit/lib/nightwatch.json');
+const nightwatchConfiguration = require('terra-toolkit/lib/nightwatch.json');
 
 module.exports = (settings => (
   testSettings(resolve('../../webpack.config'), settings)

--- a/packages/terra-clinical-detail-view/tests/nightwatch.conf.js
+++ b/packages/terra-clinical-detail-view/tests/nightwatch.conf.js
@@ -1,8 +1,8 @@
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 
-const testSettings = require('../node_modules/terra-toolkit').testSettings;
+const testSettings = require('terra-toolkit').testSettings;
 const resolve = require('path').resolve;
-const nightwatchConfiguration = require('../node_modules/terra-toolkit/lib/nightwatch.json');
+const nightwatchConfiguration = require('terra-toolkit/lib/nightwatch.json');
 
 module.exports = (settings => (
   testSettings(resolve('../../webpack.config'), settings)

--- a/packages/terra-clinical-error-view/tests/nightwatch.conf.js
+++ b/packages/terra-clinical-error-view/tests/nightwatch.conf.js
@@ -1,8 +1,8 @@
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 
-const testSettings = require('../node_modules/terra-toolkit').testSettings;
+const testSettings = require('terra-toolkit').testSettings;
 const resolve = require('path').resolve;
-const nightwatchConfiguration = require('../node_modules/terra-toolkit/lib/nightwatch.json');
+const nightwatchConfiguration = require('terra-toolkit/lib/nightwatch.json');
 
 module.exports = (settings => (
   testSettings(resolve('../../webpack.config'), settings)

--- a/packages/terra-clinical-header/tests/nightwatch.conf.js
+++ b/packages/terra-clinical-header/tests/nightwatch.conf.js
@@ -1,8 +1,8 @@
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 
-const testSettings = require('../node_modules/terra-toolkit').testSettings;
+const testSettings = require('terra-toolkit').testSettings;
 const resolve = require('path').resolve;
-const nightwatchConfiguration = require('../node_modules/terra-toolkit/lib/nightwatch.json');
+const nightwatchConfiguration = require('terra-toolkit/lib/nightwatch.json');
 
 module.exports = (settings => (
   testSettings(resolve('../../webpack.config'), settings)

--- a/packages/terra-clinical-item-display/tests/nightwatch.conf.js
+++ b/packages/terra-clinical-item-display/tests/nightwatch.conf.js
@@ -1,8 +1,8 @@
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 
-const testSettings = require('../node_modules/terra-toolkit').testSettings;
+const testSettings = require('terra-toolkit').testSettings;
 const resolve = require('path').resolve;
-const nightwatchConfiguration = require('../node_modules/terra-toolkit/lib/nightwatch.json');
+const nightwatchConfiguration = require('terra-toolkit/lib/nightwatch.json');
 
 module.exports = (settings => (
   testSettings(resolve('../../webpack.config'), settings)

--- a/packages/terra-clinical-item-view/tests/nightwatch.conf.js
+++ b/packages/terra-clinical-item-view/tests/nightwatch.conf.js
@@ -1,8 +1,8 @@
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 
-const testSettings = require('../node_modules/terra-toolkit').testSettings;
+const testSettings = require('terra-toolkit').testSettings;
 const resolve = require('path').resolve;
-const nightwatchConfiguration = require('../node_modules/terra-toolkit/lib/nightwatch.json');
+const nightwatchConfiguration = require('terra-toolkit/lib/nightwatch.json');
 
 module.exports = (settings => (
   testSettings(resolve('../../webpack.config'), settings)

--- a/packages/terra-clinical-label-value-view/tests/nightwatch.conf.js
+++ b/packages/terra-clinical-label-value-view/tests/nightwatch.conf.js
@@ -1,8 +1,8 @@
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 
-const testSettings = require('../node_modules/terra-toolkit').testSettings;
+const testSettings = require('terra-toolkit').testSettings;
 const resolve = require('path').resolve;
-const nightwatchConfiguration = require('../node_modules/terra-toolkit/lib/nightwatch.json');
+const nightwatchConfiguration = require('terra-toolkit/lib/nightwatch.json');
 
 module.exports = (settings => (
   testSettings(resolve('../../webpack.config'), settings)

--- a/packages/terra-clinical-no-data-view/tests/nightwatch.conf.js
+++ b/packages/terra-clinical-no-data-view/tests/nightwatch.conf.js
@@ -1,8 +1,8 @@
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 
-const testSettings = require('../node_modules/terra-toolkit').testSettings;
+const testSettings = require('terra-toolkit').testSettings;
 const resolve = require('path').resolve;
-const nightwatchConfiguration = require('../node_modules/terra-toolkit/lib/nightwatch.json');
+const nightwatchConfiguration = require('terra-toolkit/lib/nightwatch.json');
 
 module.exports = (settings => (
   testSettings(resolve('../../webpack.config'), settings)

--- a/packages/terra-clinical-site/webpack.config.js
+++ b/packages/terra-clinical-site/webpack.config.js
@@ -85,9 +85,9 @@ module.exports = {
   devtool: 'cheap-source-map',
   devServer: {
     host: '0.0.0.0',
-    disableHostcheck: true,
+    disableHostCheck: true,
     stats: {
-      assert: true,
+      assets: true,
       children: false,
       chunks: false,
       hash: false,

--- a/packages/terra-clinical-site/webpack.prod.config.js
+++ b/packages/terra-clinical-site/webpack.prod.config.js
@@ -2,23 +2,12 @@
 // not devDependencies. Disabling this rule in webpack.conig.js
 /* eslint-disable import/no-extraneous-dependencies */
 
-const webpack = require('webpack');
 const config = require('./webpack.config');
 const CleanPlugin = require('clean-webpack-plugin');
 const path = require('path');
 
-// https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build
-config.plugins.push(new webpack.DefinePlugin({
-  'process.env': {
-    NODE_ENV: JSON.stringify('production'),
-  },
-}));
-
 // Clean build before running
 config.plugins.push(new CleanPlugin('build', { exclude: ['stats.json'] }));
-
-// Minify css and js
-config.plugins.push(new webpack.LoaderOptionsPlugin({ minimize: true }));
 
 // Create output file
 config.output = {

--- a/tests/nightwatch.conf.js
+++ b/tests/nightwatch.conf.js
@@ -1,8 +1,8 @@
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 
-const testSettings = require('../node_modules/terra-toolkit').testSettings;
+const testSettings = require('terra-toolkit').testSettings;
 const resolve = require('path').resolve;
-const nightwatchConfiguration = require('../node_modules/terra-toolkit/lib/nightwatch.json');
+const nightwatchConfiguration = require('terra-toolkit/lib/nightwatch.json');
 
 module.exports = (settings => (
   testSettings(resolve('../../packages/terra-clinical-site/webpack.config'), settings)


### PR DESCRIPTION
### Summary
This PR addresses three issues:

1. Fixes types in the devServ configuration which is causing an error when running the script `npm run start`

2. Removes relative paths for terra-toolkit in the  `nightwatch.conf.js` files

3. Removes the configuration that defined production in the `terra-clinical-site/webpack.prod.config.js` file. The `-p` flag in the `compile:prod` and `compile:prod-stats` handle's this.

@cerner/terra
