### PR TITLE
Integrate terra-i18n-plugin into webpack config.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ lib
 node_modules
 coverage
 build
+**/aggregated-translations/*.*

--- a/packages/terra-clinical-application/tests/jest/__snapshots__/Application.test.jsx.snap
+++ b/packages/terra-clinical-application/tests/jest/__snapshots__/Application.test.jsx.snap
@@ -1,6 +1,7 @@
 exports[`test should render children with app prop 1`] = `
 <Base
-  className="terraClinical-Application">
+  className="terraClinical-Application"
+  customMessages={Object {}}>
   <div
     app={AppDelegateInstance {}}>
     TestApp
@@ -11,6 +12,7 @@ exports[`test should render children with app prop 1`] = `
 exports[`test should render custom properties on component 1`] = `
 <Base
   className="custom-class terraClinical-Application"
+  customMessages={Object {}}
   id="my-id">
   <div>
     TestApp
@@ -20,7 +22,8 @@ exports[`test should render custom properties on component 1`] = `
 
 exports[`test should render default component 1`] = `
 <Base
-  className="terraClinical-Application">
+  className="terraClinical-Application"
+  customMessages={Object {}}>
   <div>
     TestApp
   </div>

--- a/packages/terra-clinical-modal-manager/tests/nightwatch/modal-manager-spec.js
+++ b/packages/terra-clinical-modal-manager/tests/nightwatch/modal-manager-spec.js
@@ -91,7 +91,7 @@ module.exports = {
     browser.click('#DemoContainer-1 .disclose');
 
     // Waiting here to ensure new component is presented and back button is clickable
-    browser.waitForElementPresent('.terraClinical-Slide:not(.terraClinical-Slide-enter-active):nth-child(2)', 350);
+    browser.waitForElementPresent('.terraClinical-Slide:not(.terraClinical-Slide-enter-active):nth-child(2)', 1000);
 
     browser.expect.element('.terraClinical-ModalManager-modal .terraClinical-SlideGroup #DemoContainer-1').to.be.present;
     browser.expect.element('.terraClinical-ModalManager-modal .terraClinical-SlideGroup #DemoContainer-2').to.be.present;
@@ -105,4 +105,3 @@ module.exports = {
     browser.expect.element('.terraClinical-ModalManager-modal .terraClinical-SlideGroup #DemoContainer-2').to.not.be.present;
   },
 };
-

--- a/packages/terra-clinical-site/aggregated-translations/de.js
+++ b/packages/terra-clinical-site/aggregated-translations/de.js
@@ -1,0 +1,14 @@
+import { addLocaleData } from 'react-intl';
+import localeData from 'react-intl/locale-data/de';
+
+addLocaleData(localeData);
+
+const messages = {
+  "Terra.ajax.error": "Inhalt konnte nicht geladen werden."
+};
+
+module.exports = {
+  areTranslationsLoaded: true,
+  locale: 'de',
+  messages,
+};

--- a/packages/terra-clinical-site/aggregated-translations/en-GB.js
+++ b/packages/terra-clinical-site/aggregated-translations/en-GB.js
@@ -1,0 +1,14 @@
+import { addLocaleData } from 'react-intl';
+import localeData from 'react-intl/locale-data/en';
+
+addLocaleData(localeData);
+
+const messages = {
+  "Terra.ajax.error": "This content failed to load."
+};
+
+module.exports = {
+  areTranslationsLoaded: true,
+  locale: 'en-GB',
+  messages,
+};

--- a/packages/terra-clinical-site/aggregated-translations/en-US.js
+++ b/packages/terra-clinical-site/aggregated-translations/en-US.js
@@ -1,0 +1,14 @@
+import { addLocaleData } from 'react-intl';
+import localeData from 'react-intl/locale-data/en';
+
+addLocaleData(localeData);
+
+const messages = {
+  "Terra.ajax.error": "This content failed to load."
+};
+
+module.exports = {
+  areTranslationsLoaded: true,
+  locale: 'en-US',
+  messages,
+};

--- a/packages/terra-clinical-site/aggregated-translations/en.js
+++ b/packages/terra-clinical-site/aggregated-translations/en.js
@@ -1,0 +1,14 @@
+import { addLocaleData } from 'react-intl';
+import localeData from 'react-intl/locale-data/en';
+
+addLocaleData(localeData);
+
+const messages = {
+  "Terra.ajax.error": "This content failed to load."
+};
+
+module.exports = {
+  areTranslationsLoaded: true,
+  locale: 'en',
+  messages,
+};

--- a/packages/terra-clinical-site/aggregated-translations/es.js
+++ b/packages/terra-clinical-site/aggregated-translations/es.js
@@ -1,0 +1,14 @@
+import { addLocaleData } from 'react-intl';
+import localeData from 'react-intl/locale-data/es';
+
+addLocaleData(localeData);
+
+const messages = {
+  "Terra.ajax.error": "Error al cargar el contenido."
+};
+
+module.exports = {
+  areTranslationsLoaded: true,
+  locale: 'es',
+  messages,
+};

--- a/packages/terra-clinical-site/aggregated-translations/fi-FI.js
+++ b/packages/terra-clinical-site/aggregated-translations/fi-FI.js
@@ -1,0 +1,14 @@
+import { addLocaleData } from 'react-intl';
+import localeData from 'react-intl/locale-data/fi';
+
+addLocaleData(localeData);
+
+const messages = {
+  "Terra.ajax.error": "This content failed to load.n9KZ Pi~"
+};
+
+module.exports = {
+  areTranslationsLoaded: true,
+  locale: 'fi-FI',
+  messages,
+};

--- a/packages/terra-clinical-site/aggregated-translations/fr.js
+++ b/packages/terra-clinical-site/aggregated-translations/fr.js
@@ -1,0 +1,14 @@
+import { addLocaleData } from 'react-intl';
+import localeData from 'react-intl/locale-data/fr';
+
+addLocaleData(localeData);
+
+const messages = {
+  "Terra.ajax.error": "Échec du chargement du contenu."
+};
+
+module.exports = {
+  areTranslationsLoaded: true,
+  locale: 'fr',
+  messages,
+};

--- a/packages/terra-clinical-site/aggregated-translations/pt.js
+++ b/packages/terra-clinical-site/aggregated-translations/pt.js
@@ -1,0 +1,14 @@
+import { addLocaleData } from 'react-intl';
+import localeData from 'react-intl/locale-data/pt';
+
+addLocaleData(localeData);
+
+const messages = {
+  "Terra.ajax.error": "Falha ao carregar conteúdo."
+};
+
+module.exports = {
+  areTranslationsLoaded: true,
+  locale: 'pt',
+  messages,
+};

--- a/packages/terra-clinical-site/package.json
+++ b/packages/terra-clinical-site/package.json
@@ -49,6 +49,7 @@
     "terra-clinical-modal-manager": "^0.x",
     "terra-icon": "^0.x",
     "terra-grid": "^2.x",
+    "terra-i18n-plugin": "^0.x",
     "terra-legacy-theme": "^0.x",
     "terra-list": "^0.x",
     "terra-markdown": "^0.x",

--- a/packages/terra-clinical-site/src/App.jsx
+++ b/packages/terra-clinical-site/src/App.jsx
@@ -11,9 +11,10 @@ import './site.scss';
 const propTypes = {
   children: PropTypes.node,
 };
+const locale = document.getElementsByTagName('html')[0].getAttribute('lang');
 
 const App = props => (
-  <Base>
+  <Base locale={locale}>
     <Grid>
       <Grid.Row>
         <Grid.Column small={2}>

--- a/packages/terra-clinical-site/webpack.config.js
+++ b/packages/terra-clinical-site/webpack.config.js
@@ -7,6 +7,8 @@ const path = require('path');
 const Autoprefixer = require('autoprefixer');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const I18nAggregatorPlugin = require('terra-i18n-plugin');
+const i18nSupportedLocales = require('terra-i18n/lib/i18nSupportedLocales');
 
 module.exports = {
   entry: {
@@ -66,11 +68,16 @@ module.exports = {
       template: path.join(__dirname, 'src', 'index.html'),
       chunks: ['terra-clinical'],
     }),
+    new I18nAggregatorPlugin({
+      baseDirectory: __dirname,
+      supportedLocales: i18nSupportedLocales,
+    }),
     new webpack.NamedChunksPlugin(),
   ],
   resolve: {
     // See https://github.com/facebook/react/issues/8026
     extensions: ['.js', '.jsx'],
+    modules: [path.resolve(__dirname, 'aggregated-translations'), 'node_modules'],
     alias: {
       moment: path.resolve(__dirname, 'node_modules/moment'),
       react: path.resolve(__dirname, 'node_modules', 'react'),


### PR DESCRIPTION
### Summary
With `terra-base` v0.5.0 released, the `terra-i18n-plugin` needed incorporated into terra-clinical-site webpack configuration. Without the integration, errors were thrown and the script `npm run start` failed to compile. 

@cerner/terra
