### PR TITLE
Adding en translations for terra-clinical-action-header

### DIFF
--- a/packages/terra-clinical-action-header/translations/en.json
+++ b/packages/terra-clinical-action-header/translations/en.json
@@ -1,0 +1,8 @@
+{
+  "Terra.Clinical.ActionHeader.close": "Close",
+  "Terra.Clinical.ActionHeader.back": "Back",
+  "Terra.Clinical.ActionHeader.previous": "Previous",
+  "Terra.Clinical.ActionHeader.next": "Next",
+  "Terra.Clinical.ActionHeader.maximize": "Maximize",
+  "Terra.Clinical.ActionHeader.minimize": "Minimize"
+}


### PR DESCRIPTION
### Summary
Adding `en` translations for terra-clincial action header.

Supported locales
https://github.com/cerner/terra-core/blob/cb6e4259e33af5ddad2ca1a6cdca07fb819eaebf/packages/terra-i18n/src/i18nSupportedLocales.js


Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
