### PR TITLE
Update Item Display Styling

### DIFF
--- a/packages/terra-clinical-item-display/src/ItemComment.scss
+++ b/packages/terra-clinical-item-display/src/ItemComment.scss
@@ -1,7 +1,7 @@
 @import './mixins';
 
 .terraClinical-ItemComment {
-  @include terra-clinical-text-body;
+  @include terra-clinical-item-body;
   color: #64696c;
 }
 

--- a/packages/terra-clinical-item-display/src/ItemDisplay.scss
+++ b/packages/terra-clinical-item-display/src/ItemDisplay.scss
@@ -2,6 +2,7 @@
 @import './mixins';
 
 .terraClinical-ItemDisplay {
+  @include terra-clinical-item-body;
   align-items: center;
   display: flex;
   overflow: hidden; // VERY IMPORTANT FOR IE10

--- a/packages/terra-clinical-item-display/src/_mixins.scss
+++ b/packages/terra-clinical-item-display/src/_mixins.scss
@@ -6,7 +6,7 @@
   word-wrap: normal;
 }
 
-@mixin terra-clinical-text-body {
+@mixin terra-clinical-item-body {
   font-size: 1.1428571428571428rem;
   line-height: 1.4285714285714286;
 

--- a/packages/terra-clinical-item-view/src/ItemView.scss
+++ b/packages/terra-clinical-item-view/src/ItemView.scss
@@ -101,7 +101,6 @@
 // We need to style content that appears out of the rowContainer (i.e. the comment).
 .terraClinical-ItemView-content {
   .terraClinical-ItemDisplay {
-    @include terra-clinical-text-body;
     color: #64696c;
   }
 }


### PR DESCRIPTION
### Summary
Looking at the Item Display site page, the bottom of the text is cut off.  When the item-display was a subcomponent of the item-view, the item-view handled the styling that applied a default font-size and line-height. This PR moves this default styling into the item-display package. 

Thanks for contributing to Terra. 
@cerner/terra
