### PR TITLE
props-table-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ screenshots
 target
 **/aggregated-translations/*.*
 lib
-**/aggregated-translations/*.*
+props-table
+

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "lint:scss": "lerna run lint:scss",
     "pretest": "npm run lint",
     "postinstall": "npm run compile && npm run bootstrap",
-    "publish": "check-installed-dependencies && npm run compile && npm test && lerna publish",
+    "props-table": "lerna run props-table",
+    "publish": "check-installed-dependencies && npm run compile && npm test && npm run props-table && lerna publish",
     "start": "cd packages/terra-clinical-site && npm run start",
     "start:express": "node scripts/express/app.js",
     "test": "jest && npm run test:nightwatch-default",
@@ -89,6 +90,7 @@
     "shelljs": "^0.7.7",
     "stylelint": "^7.10.1",
     "stylelint-config-sass-guidelines": "^2.1.0",
+    "terra-props-table": "^0.9.0",
     "terra-toolkit": "^0.x"
   }
 }

--- a/packages/terra-clinical-action-header/package.json
+++ b/packages/terra-clinical-action-header/package.json
@@ -52,6 +52,7 @@
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
+    "props-table": "$(cd ..; npm bin)/props-table ./src/ActionHeader.jsx --out-dir ./docs/props-table",
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",

--- a/packages/terra-clinical-application/package.json
+++ b/packages/terra-clinical-application/package.json
@@ -42,6 +42,7 @@
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
+    "props-table": "$(cd ..; npm bin)/props-table ./src/Application.jsx --out-dir ./docs/props-table",
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",

--- a/packages/terra-clinical-detail-view/package.json
+++ b/packages/terra-clinical-detail-view/package.json
@@ -39,6 +39,7 @@
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
+    "props-table": "$(cd ..; npm bin)/props-table ./src/DetailList.jsx ./src/DetailListItem.jsx ./src/DetailView.jsx --out-dir ./docs/props-table",
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",

--- a/packages/terra-clinical-error-view/package.json
+++ b/packages/terra-clinical-error-view/package.json
@@ -44,6 +44,7 @@
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
+    "props-table": "$(cd ..; npm bin)/props-table ./src/ErrorView.jsx --out-dir ./docs/props-table",
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",

--- a/packages/terra-clinical-header/package.json
+++ b/packages/terra-clinical-header/package.json
@@ -42,6 +42,7 @@
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
+    "props-table": "$(cd ..; npm bin)/props-table ./src/Header.jsx --out-dir ./docs/props-table",
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",

--- a/packages/terra-clinical-item-display/package.json
+++ b/packages/terra-clinical-item-display/package.json
@@ -42,6 +42,7 @@
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
+    "props-table": "$(cd ..; npm bin)/props-table ./src/ItemDisplay.jsx ./src/ItemComment.jsx --out-dir ./docs/props-table",
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",

--- a/packages/terra-clinical-item-view/package.json
+++ b/packages/terra-clinical-item-view/package.json
@@ -43,6 +43,7 @@
     "compile:build": "$(cd ..; npm bin)/babel src --out-dir lib --copy-files",
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
+    "props-table": "$(cd ..; npm bin)/props-table ./src/ItemView.jsx --out-dir ./docs/props-table",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",

--- a/packages/terra-clinical-label-value-view/package.json
+++ b/packages/terra-clinical-label-value-view/package.json
@@ -40,6 +40,7 @@
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
+    "props-table": "$(cd ..; npm bin)/props-table ./src/LabelValueView.jsx --out-dir ./docs/props-table",
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",

--- a/packages/terra-clinical-modal-manager/package.json
+++ b/packages/terra-clinical-modal-manager/package.json
@@ -51,6 +51,7 @@
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
+    "props-table": "$(cd ..; npm bin)/props-table ./src/ModalManager.jsx --out-dir ./docs/props-table",
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",

--- a/packages/terra-clinical-no-data-view/package.json
+++ b/packages/terra-clinical-no-data-view/package.json
@@ -42,6 +42,7 @@
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
+    "props-table": "$(cd ..; npm bin)/props-table ./src/NoDataView.jsx --out-dir ./docs/props-table",
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",

--- a/packages/terra-clinical-slide-group/package.json
+++ b/packages/terra-clinical-slide-group/package.json
@@ -41,6 +41,7 @@
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
+    "props-table": "$(cd ..; npm bin)/props-table ./src/SlideGroup.jsx --out-dir ./docs/props-table",
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",


### PR DESCRIPTION
### Summary
Generating a props-table for each component when publishing. This matches the work done in terra-core here: https://github.com/cerner/terra-core/pull/473 
In terra-core, terra-props-table is installed in each package. In terra-clinical, we only need to install it in the root package.json. 

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
