### PR TITLE
Fix Item View UX Issues

### DIFF
--- a/packages/terra-clinical-item-view/CHANGELOG.md
+++ b/packages/terra-clinical-item-view/CHANGELOG.md
@@ -5,6 +5,10 @@ Unreleased
 ----------
 ### Fixed
 * Fixed accessory styling to scale with font size.
+* Fixed truncation styling to correctly apply an ellipse.
+
+## Changed
+* Updated Accessory nightwatch examples to include an icon.
 
 1.1.0 - (July 18, 2017)
 -----------------

--- a/packages/terra-clinical-item-view/CHANGELOG.md
+++ b/packages/terra-clinical-item-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* Fixed accessory styling to scale with font size.
 
 1.1.0 - (July 18, 2017)
 -----------------

--- a/packages/terra-clinical-item-view/src/ItemView.jsx
+++ b/packages/terra-clinical-item-view/src/ItemView.jsx
@@ -59,7 +59,7 @@ class ItemView extends React.Component {
     let accessorySection;
     if (accessory) {
       accessorySection = (
-        <div className={cx('accessory', { [`accessory--${accessoryAlignment}`]: accessoryAlignment })}>
+        <div className={cx('accessory', { [`accessory-${accessoryAlignment}`]: accessoryAlignment })}>
           {accessory}
         </div>
       );
@@ -118,17 +118,17 @@ class ItemView extends React.Component {
   }
 
   static defaultEmphasisContentClassesFromIndexes(rowIndex, rowCount) {
-    let contentSize = 'content--primarySize';
-    let contentColor = 'content--primaryColor';
+    let contentSize = 'content-primarySize';
+    let contentColor = 'content-primaryColor';
 
     if (rowIndex > 0) {
-      contentSize = 'content--secondarySize';
+      contentSize = 'content-secondarySize';
     }
 
     if (rowCount === 2 && rowIndex === 1) {
-      contentColor = 'content--secondaryColor';
+      contentColor = 'content-secondaryColor';
     } else if (rowIndex >= 2) {
-      contentColor = 'content--secondaryColor';
+      contentColor = 'content-secondaryColor';
     }
 
     return [contentSize, contentColor];
@@ -136,7 +136,7 @@ class ItemView extends React.Component {
 
   static startEmphasisContentClassesFromIndexes(rowIndex, rowCount, contentIndex) {
     if (contentIndex === 1) {
-      return ['content--secondarySize', 'content--secondaryColor'];
+      return ['content-secondarySize', 'content-secondaryColor'];
     }
 
     return ItemView.defaultEmphasisContentClassesFromIndexes(rowIndex, rowCount);

--- a/packages/terra-clinical-item-view/src/ItemView.scss
+++ b/packages/terra-clinical-item-view/src/ItemView.scss
@@ -49,7 +49,7 @@
   }
 
   .content {
-    align-items: center;
+    align-items: flex-start;
     color: #64696c;
     display: flex;
     overflow: hidden; // VERY IMPORTANT FOR IE10

--- a/packages/terra-clinical-item-view/src/ItemView.scss
+++ b/packages/terra-clinical-item-view/src/ItemView.scss
@@ -11,19 +11,27 @@
     word-wrap: break-word;
   }
 
-  // Accessory-- is of fixed size and does not shrink or grow.
+  // Accessory is of fixed size and does not shrink or grow.
   .accessory {
     flex: 0 0 auto;
     margin: 5px;
+    max-height: 60px;
+    max-width: 60px;
     min-width: 0;
     overflow: hidden;
   }
 
-  .accessory--alignTop {
+  .accessory > * {
+    vertical-align: 0 !important;
+    max-height: 60px;
+    max-width: 60px;
+  }
+
+  .accessory-alignTop {
     align-self: flex-start;
   }
 
-  .accessory--alignCenter {
+  .accessory-alignCenter {
     align-self: center;
   }
 
@@ -42,11 +50,11 @@
 
   .content {
     align-items: center;
+    color: #64696c;
     display: flex;
     overflow: hidden; // VERY IMPORTANT FOR IE10
   }
-
-  .is-truncated {
+  .is-truncated, .is-truncated [class*="ItemDisplay__text"] {
     @include terra-clinical-text-truncate;
   }
 
@@ -54,10 +62,8 @@
   /* stylelint-disable selector-max-compound-selectors */
   .oneColumn {
     .row-container {
-      .row {
-        flex-flow: column nowrap;
-        justify-content: flex-start;
-      }
+      display: flex;
+      flex-flow: row wrap;
 
       .content {
         width: 100%;
@@ -65,11 +71,10 @@
     }
   }
   /* stylelint-enable selector-max-compound-selectors */
-
   .twoColumns {
     .content:nth-child(odd) {
       flex: 1 1 auto;
-      text-align: left;
+      justify-content: flex-start;
     }
 
     .content:nth-child(even) {
@@ -82,25 +87,20 @@
     }
   }
 
-  // We need to style content that appears out of the rowContainer (i.e. the comment).
-  .content {
-    color: #64696c;
-  }
-
   //Emphasis Content Styles
-  .content--primaryColor {
+  .content-primaryColor {
     color: #1c1f21;
   }
 
-  .content--primarySize {
+  .content-primarySize {
     @include terra-clinical-tiny-heading;
   }
 
-  .content--secondaryColor {
+  .content-secondaryColor {
     color: #64696c;
   }
 
-  .content--secondarySize {
+  .content-secondarySize {
     @include terra-clinical-text-body;
   }
 }

--- a/packages/terra-clinical-item-view/src/ItemView.scss
+++ b/packages/terra-clinical-item-view/src/ItemView.scss
@@ -15,8 +15,6 @@
   .accessory {
     flex: 0 0 auto;
     margin: 5px;
-    max-height: 60px;
-    max-width: 60px;
     min-width: 0;
     overflow: hidden;
   }

--- a/packages/terra-clinical-item-view/src/ItemView.scss
+++ b/packages/terra-clinical-item-view/src/ItemView.scss
@@ -22,7 +22,7 @@
   }
 
   .accessory > * {
-    vertical-align: 0 !important;
+    display: flex !important;
     max-height: 60px;
     max-width: 60px;
   }
@@ -54,7 +54,9 @@
     display: flex;
     overflow: hidden; // VERY IMPORTANT FOR IE10
   }
-  .is-truncated, .is-truncated [class*="ItemDisplay__text"] {
+
+  .is-truncated,
+  .is-truncated [class*='ItemDisplay__text'] {
     @include terra-clinical-text-truncate;
   }
 

--- a/packages/terra-clinical-item-view/tests/jest/__snapshots__/ItemView.test.jsx.snap
+++ b/packages/terra-clinical-item-view/tests/jest/__snapshots__/ItemView.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`test should render 1 start theme display 1`] = `
       <div
         className="row">
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 1" />
@@ -29,7 +29,7 @@ exports[`test should render 2 start theme displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 1" />
@@ -38,7 +38,7 @@ exports[`test should render 2 start theme displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--secondarySize content--secondaryColor">
+          className="content content-secondarySize content-secondaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 2" />
@@ -59,7 +59,7 @@ exports[`test should render 3 start theme displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 1" />
@@ -68,7 +68,7 @@ exports[`test should render 3 start theme displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--secondarySize content--primaryColor">
+          className="content content-secondarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 2" />
@@ -77,7 +77,7 @@ exports[`test should render 3 start theme displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--secondarySize content--secondaryColor">
+          className="content content-secondarySize content-secondaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 3" />
@@ -115,7 +115,7 @@ exports[`test should render a end accessory 1`] = `
   <div
     className="body" />
   <div
-    className="accessory accessory--alignCenter">
+    className="accessory accessory-alignCenter">
     <img
       alt="Graphic" />
   </div>
@@ -126,7 +126,7 @@ exports[`test should render a start accessory 1`] = `
 <div
   className="item-view oneColumn">
   <div
-    className="accessory accessory--alignCenter">
+    className="accessory accessory-alignCenter">
     <img
       alt="Graphic" />
   </div>
@@ -139,7 +139,7 @@ exports[`test should render an accessory center aligned 1`] = `
 <div
   className="item-view oneColumn">
   <div
-    className="accessory accessory--alignCenter">
+    className="accessory accessory-alignCenter">
     <img
       alt="Graphic" />
   </div>
@@ -152,7 +152,7 @@ exports[`test should render an accessory top aligned 1`] = `
 <div
   className="item-view oneColumn">
   <div
-    className="accessory accessory--alignTop">
+    className="accessory accessory-alignTop">
     <img
       alt="Graphic" />
   </div>
@@ -171,7 +171,7 @@ exports[`test should render one column 1`] = `
       <div
         className="row">
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 1" />
@@ -180,7 +180,7 @@ exports[`test should render one column 1`] = `
       <div
         className="row">
         <div
-          className="content content--secondarySize content--secondaryColor">
+          className="content content-secondarySize content-secondaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 2" />
@@ -201,7 +201,7 @@ exports[`test should render truncated display 1`] = `
       <div
         className="row">
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={true}
             text="display1display1display1display1display1display1display1display1" />
@@ -222,13 +222,13 @@ exports[`test should render two columns with 8 displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 1" />
         </div>
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 2" />
@@ -237,13 +237,13 @@ exports[`test should render two columns with 8 displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--secondarySize content--primaryColor">
+          className="content content-secondarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 3" />
         </div>
         <div
-          className="content content--secondarySize content--primaryColor">
+          className="content content-secondarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 4" />
@@ -252,13 +252,13 @@ exports[`test should render two columns with 8 displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--secondarySize content--secondaryColor">
+          className="content content-secondarySize content-secondaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 5" />
         </div>
         <div
-          className="content content--secondarySize content--secondaryColor">
+          className="content content-secondarySize content-secondaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 6" />
@@ -267,13 +267,13 @@ exports[`test should render two columns with 8 displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--secondarySize content--secondaryColor">
+          className="content content-secondarySize content-secondaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 7" />
         </div>
         <div
-          className="content content--secondarySize content--secondaryColor">
+          className="content content-secondarySize content-secondaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 8" />
@@ -294,13 +294,13 @@ exports[`test should render two columns with odd number of displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 1" />
         </div>
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 2" />
@@ -309,7 +309,7 @@ exports[`test should render two columns with odd number of displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--secondarySize content--secondaryColor">
+          className="content content-secondarySize content-secondaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 3" />
@@ -330,7 +330,7 @@ exports[`test should render with 1 display 1`] = `
       <div
         className="row">
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 1" />
@@ -351,7 +351,7 @@ exports[`test should render with 2 displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 1" />
@@ -360,7 +360,7 @@ exports[`test should render with 2 displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--secondarySize content--secondaryColor">
+          className="content content-secondarySize content-secondaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 2" />
@@ -381,7 +381,7 @@ exports[`test should render with 3 displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 1" />
@@ -390,7 +390,7 @@ exports[`test should render with 3 displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--secondarySize content--primaryColor">
+          className="content content-secondarySize content-primaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 2" />
@@ -399,7 +399,7 @@ exports[`test should render with 3 displays 1`] = `
       <div
         className="row">
         <div
-          className="content content--secondarySize content--secondaryColor">
+          className="content content-secondarySize content-secondaryColor">
           <ItemDisplay
             isTruncated={false}
             text="display 3" />
@@ -420,7 +420,7 @@ exports[`test should render with a display and graphic 1`] = `
       <div
         className="row">
         <div
-          className="content content--primarySize content--primaryColor">
+          className="content content-primarySize content-primaryColor">
           <ItemDisplay
             icon={
               <img

--- a/packages/terra-clinical-item-view/tests/nightwatch/AccessoryItemView.jsx
+++ b/packages/terra-clinical-item-view/tests/nightwatch/AccessoryItemView.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
+import IconAlert from 'terra-icon/lib/icon/IconAlert';
+import IconInformation from 'terra-icon/lib/icon/IconInformation';
 import ItemView from '../../lib/ItemView';
-
-const accessoryStart = <img alt="Graphic Start" id="StartAccessory" />;
-const accessoryEnd = <img alt="Graphic End" id="EndAccessory" />;
 
 const views = () => (
   <div>
     <h2>Start Acessory</h2>
-    <ItemView startAccessory={accessoryStart} id="test-start-accessory" />
+    <ItemView startAccessory={<IconAlert id="StartAccessory" />} id="test-start-accessory" />
     <h2>End Acessory</h2>
-    <ItemView endAccessory={accessoryEnd} id="test-end-accessory" />
+    <ItemView endAccessory={<IconInformation id="EndAccessory" />} id="test-end-accessory" />
     <h2>Start and End Acessory</h2>
-    <ItemView startAccessory={accessoryStart} endAccessory={accessoryEnd} accessoryAlignment="alignTop" id="test-both-accessory-top" />
+    <ItemView startAccessory={<IconAlert id="StartAccessory" />} endAccessory={<IconInformation id="EndAccessory" />} accessoryAlignment="alignTop" id="test-both-accessory-top" />
+    <h2>Scaled Accessories with Font Size 100px (max-height and max-width is 60px)</h2>
+    <ItemView startAccessory={<IconAlert />} endAccessory={<IconInformation />} id="test-both-scale" style={{ fontSize: '100px' }} />
   </div>
 );
 

--- a/packages/terra-clinical-item-view/tests/nightwatch/CommentItemView.jsx
+++ b/packages/terra-clinical-item-view/tests/nightwatch/CommentItemView.jsx
@@ -1,6 +1,16 @@
 import React from 'react';
 import ItemView from '../../lib/ItemView';
 
-const comment1 = <ItemView.Comment text="comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1" id="ItemComment" />;
+const comment = <ItemView.Comment text="comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1" id="ItemComment" />;
 
-export default () => <ItemView comment={comment1} id="ItemView" />;
+const ItemViews = () => (
+  <div style={{ width: '250px' }}>
+    <h2>Default</h2>
+    <ItemView comment={comment} id="ItemView1" />
+    <br />
+    <h2>Truncated</h2>
+    <ItemView isTruncated comment={comment} id="ItemView2" />
+  </div>
+);
+
+export default ItemViews;

--- a/packages/terra-clinical-item-view/tests/nightwatch/ItemViewTestRoutes.jsx
+++ b/packages/terra-clinical-item-view/tests/nightwatch/ItemViewTestRoutes.jsx
@@ -7,6 +7,7 @@ import DefaultItemView from './DefaultItemView';
 import DisplaysItemView from './DisplaysItemView';
 import AccessoryItemView from './AccessoryItemView';
 import CommentItemView from './CommentItemView';
+import OverflowDisplaysItemView from './OverflowDisplaysItemView';
 
 const routes = (
   <div>
@@ -15,6 +16,7 @@ const routes = (
     <Route path="/tests/item-view-tests/displays" component={DisplaysItemView} />
     <Route path="/tests/item-view-tests/accessory" component={AccessoryItemView} />
     <Route path="/tests/item-view-tests/comment" component={CommentItemView} />
+    <Route path="/tests/item-view-tests/overflow" component={OverflowDisplaysItemView} />
   </div>
 );
 

--- a/packages/terra-clinical-item-view/tests/nightwatch/ItemViewTests.jsx
+++ b/packages/terra-clinical-item-view/tests/nightwatch/ItemViewTests.jsx
@@ -10,6 +10,7 @@ const ItemViewTests = () => (
       <li><Link to="/tests/item-view-tests/displays">ItemView - Displays</Link></li>
       <li><Link to="/tests/item-view-tests/accessory">ItemView - Accesory</Link></li>
       <li><Link to="/tests/item-view-tests/comment">ItemView - Comment</Link></li>
+      <li><Link to="/tests/item-view-tests/overflow">ItemView - Word Wrap vs Truncated</Link></li>
     </ul>
   </div>
 );

--- a/packages/terra-clinical-item-view/tests/nightwatch/OverflowDisplaysItemView.jsx
+++ b/packages/terra-clinical-item-view/tests/nightwatch/OverflowDisplaysItemView.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import ItemView from '../../src/ItemView';
+
+const display1 = <ItemView.Display text="display1display1display1display1display1display1display1display1display1display1display1display1display1display1" key="123" />;
+const display2 = <ItemView.Display text="display2display2display2display2display2display2display2display2display2display2display2display2display2display2" key="124" />;
+const display3 = <ItemView.Display text="display 3" key="125" />;
+const display4 = <ItemView.Display text="display 4" key="126" />;
+const display5 = <ItemView.Display text="display 5" key="127" />;
+const display6 = <ItemView.Display text="display 6" key="128" />;
+const displays = [display1, display2, display3, display4, display5, display6];
+
+const accessoryStart = <img alt="Graphic Start" id="StartAccessory" />;
+const accessoryEnd = <img alt="Graphic End" id="EndAccessory" />;
+const comment = <ItemView.Comment text="comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1" id="ItemComment" />;
+
+const views = () => (
+  <div style={{ width: '900px' }}>
+    <p>Applied width of 900px to show the default vs truncated styling.</p>
+    <br />
+    <h2>Full Examples - Default</h2>
+    <ItemView comment={comment} startAccessory={accessoryStart} endAccessory={accessoryEnd} displays={displays} id="ItemView-one-wrap" />
+    <br />
+    <ItemView comment={comment} startAccessory={accessoryStart} endAccessory={accessoryEnd} displays={displays} layout="twoColumns" id="ItemView-two-wrap" />
+    <br />
+    <h2>Full Examples - Truncated</h2>
+    <ItemView displays={displays} isTruncated comment={comment} startAccessory={accessoryStart} endAccessory={accessoryEnd} textEmphasis="start" id="ItemView-one-truncate" />
+    <br />
+    <ItemView displays={displays} isTruncated comment={comment} startAccessory={accessoryStart} endAccessory={accessoryEnd} layout="twoColumns" textEmphasis="start" id="ItemView-two-truncate" />
+  </div>
+);
+
+export default views;

--- a/packages/terra-clinical-item-view/tests/nightwatch/OverflowDisplaysItemView.jsx
+++ b/packages/terra-clinical-item-view/tests/nightwatch/OverflowDisplaysItemView.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import ItemView from '../../src/ItemView';
+import IconAlert from 'terra-icon/lib/icon/IconAlert';
+import IconInformation from 'terra-icon/lib/icon/IconInformation';
+import ItemView from '../../lib/ItemView';
 
 const display1 = <ItemView.Display text="display1display1display1display1display1display1display1display1display1display1display1display1display1display1" key="123" />;
 const display2 = <ItemView.Display text="display2display2display2display2display2display2display2display2display2display2display2display2display2display2" key="124" />;
@@ -9,12 +11,12 @@ const display5 = <ItemView.Display text="display 5" key="127" />;
 const display6 = <ItemView.Display text="display 6" key="128" />;
 const displays = [display1, display2, display3, display4, display5, display6];
 
-const accessoryStart = <img alt="Graphic Start" id="StartAccessory" />;
-const accessoryEnd = <img alt="Graphic End" id="EndAccessory" />;
+const accessoryStart = <IconAlert id="StartAccessory" />;
+const accessoryEnd = <IconInformation id="EndAccessory" />;
 const comment = <ItemView.Comment text="comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1comment1" id="ItemComment" />;
 
 const views = () => (
-  <div style={{ width: '900px' }}>
+  <div style={{ maxWidth: '900px' }}>
     <p>Applied width of 900px to show the default vs truncated styling.</p>
     <br />
     <h2>Full Examples - Default</h2>

--- a/packages/terra-clinical-item-view/tests/nightwatch/item-view-spec.js
+++ b/packages/terra-clinical-item-view/tests/nightwatch/item-view-spec.js
@@ -46,4 +46,12 @@ module.exports = {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/item-view-tests/comment`);
     browser.assert.elementPresent('#ItemView #ItemComment');
   },
+
+  'Displays a clinical item view with the word wrap and truncation': (browser) => {
+    browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/item-view-tests/overflow`);
+    browser.assert.elementPresent('#ItemView-one-wrap');
+    browser.assert.elementPresent('#ItemView-two-wrap');
+    browser.assert.elementPresent('#ItemView-one-truncate');
+    browser.assert.elementPresent('#ItemView-two-truncate');
+  },
 };

--- a/packages/terra-clinical-item-view/tests/nightwatch/item-view-spec.js
+++ b/packages/terra-clinical-item-view/tests/nightwatch/item-view-spec.js
@@ -44,7 +44,7 @@ module.exports = {
 
   'Displays a clinical item view with a comment set': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/item-view-tests/comment`);
-    browser.assert.elementPresent('#ItemView #ItemComment');
+    browser.assert.elementPresent('#ItemView1 #ItemComment');
   },
 
   'Displays a clinical item view with the word wrap and truncation': (browser) => {


### PR DESCRIPTION
### Summary
This PR addresses a few issues with Item View.

1. Fixes Icon Scaling. Closes #115.
2. When adding an example in the nightwatch for scaling, added icons to the accessory examples to provide more context. Closes #149.
3. Fixed Truncation styling. Closes #148.
4. Updated class names to use a '-' instead of a '--'.

@cerner/terra
