### PR TITLE
Update data class attrs

### DIFF
--- a/packages/terra-clinical-action-header/CHANGELOG.md
+++ b/packages/terra-clinical-action-header/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change data-class to be name spaced
 
 1.1.1 - (July 27, 2017)
 -----------------

--- a/packages/terra-clinical-action-header/src/ActionHeader.jsx
+++ b/packages/terra-clinical-action-header/src/ActionHeader.jsx
@@ -168,7 +168,7 @@ const ActionHeader = ({
   const actionHeader = (
     <Header
       {...attributes}
-      data-class="action-header"
+      data-terra-clincial-action-header
       startContent={leftButtonsDefault}
       title={title}
       endContent={rightButtonsDefault}
@@ -178,7 +178,7 @@ const ActionHeader = ({
   const smallActionHeader = (
     <Header
       {...attributes}
-      data-class="action-header"
+      data-terra-clincial-action-header
       startContent={leftButtonsSmall}
       title={title}
       endContent={rightButtonsSmall}

--- a/packages/terra-clinical-detail-view/CHANGELOG.md
+++ b/packages/terra-clinical-detail-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change data-class to be name spaced
 
 1.1.1 - (July 27, 2017)
 -----------------

--- a/packages/terra-clinical-detail-view/src/DetailList.jsx
+++ b/packages/terra-clinical-detail-view/src/DetailList.jsx
@@ -34,7 +34,7 @@ const DetailList = ({ title, children, ...customProps }) => {
   }
 
   return (
-    <div {...customProps} data-class="detail-list" className={customProps.className}>
+    <div {...customProps} data-terra-clincial-detail-list className={customProps.className}>
       {titleContent}
       <div className={cx('list')}>
         {children}

--- a/packages/terra-clinical-detail-view/tests/jest/DetailList.test.jsx
+++ b/packages/terra-clinical-detail-view/tests/jest/DetailList.test.jsx
@@ -42,11 +42,6 @@ it('should set the title text', () => {
 });
 
 // Structure Tests
-it('should have the class detail-list', () => {
-  const wrapper = shallow(defaultVariety);
-  expect(wrapper.prop('data-class')).toContain('detail-list');
-});
-
 it('should have the class title when title is provided', () => {
   const wrapper = shallow(defaultVariety);
   expect(wrapper.childAt(0).prop('className')).toContain('title');

--- a/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailList.test.jsx.snap
+++ b/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailList.test.jsx.snap
@@ -1,6 +1,6 @@
 exports[`test should render a default component 1`] = `
 <div
-  data-class="detail-list">
+  data-terra-clincial-detail-list="true">
   <div
     class="list" />
 </div>
@@ -8,7 +8,7 @@ exports[`test should render a default component 1`] = `
 
 exports[`test should render a list 1`] = `
 <div
-  data-class="detail-list">
+  data-terra-clincial-detail-list="true">
   <div
     class="list">
     <div
@@ -29,7 +29,7 @@ exports[`test should render a list 1`] = `
 
 exports[`test should render a title 1`] = `
 <div
-  data-class="detail-list">
+  data-terra-clincial-detail-list="true">
   <div
     class="title">
     Title
@@ -41,7 +41,7 @@ exports[`test should render a title 1`] = `
 
 exports[`test should render a title and a list 1`] = `
 <div
-  data-class="detail-list">
+  data-terra-clincial-detail-list="true">
   <div
     class="title">
     Title

--- a/packages/terra-clinical-item-collection/CHANGELOG.md
+++ b/packages/terra-clinical-item-collection/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change data-class to be name spaced
 
 1.1.1 - (July 27, 2017)
 -----------------

--- a/packages/terra-clinical-item-collection/src/ItemCollection.jsx
+++ b/packages/terra-clinical-item-collection/src/ItemCollection.jsx
@@ -93,14 +93,14 @@ class ItemCollection extends React.Component {
 
     const tableView = createTableView(rows, tableStyles, this.state.selectedIndex, this.handleSelection);
     const tableDisplay = (
-      <div {...customProps} data-class="item-collection table-view" className={customProps.className}>
+      <div {...customProps} data-terra-clinical-item-collection-table-view className={customProps.className}>
         {tableView}
       </div>
     );
 
     const listView = createListView(rows, listStyles, this.state.selectedIndex, this.handleSelection);
     const listDisplay = (
-      <div {...customProps} data-class="item-collection list-view" className={customProps.className}>
+      <div {...customProps} data-terra-clinical-item-collection-list-view className={customProps.className}>
         {listView}
       </div>
     );

--- a/packages/terra-clinical-item-collection/src/_CreateTableView.jsx
+++ b/packages/terra-clinical-item-collection/src/_CreateTableView.jsx
@@ -61,7 +61,7 @@ function createTableCell(content, keyValue, contentType) {
   if (contentType === 'accessory') {
     return (<Table.Cell content={cellContent} key={keyValue} className={cx(`content-${contentType}`)} />);
   }
-  return (<Table.Cell content={cellContent} key={keyValue} data-class={cx(`content-${contentType}`)} />);
+  return (<Table.Cell content={cellContent} key={keyValue} data-terra-clinical-item-collection-content={`${contentType}`} />);
 }
 
 function createTableRows(rows, tableColumns, selectedIndex) {

--- a/packages/terra-clinical-item-collection/src/_TableHeaderCell.jsx
+++ b/packages/terra-clinical-item-collection/src/_TableHeaderCell.jsx
@@ -20,7 +20,7 @@ const TableHeaderCell = ({ columnType, ...customProps }) => {
   if (columnType === 'accessory') {
     return (<th {...customProps} className={cx(`column-${columnType}`)} />);
   }
-  return (<th {...customProps} data-class={cx(`column-${columnType}`)} />);
+  return (<th {...customProps} data-terra-clinical-item-collection-column={`${columnType}`} />);
 };
 
 TableHeaderCell.propTypes = propTypes;

--- a/packages/terra-clinical-item-collection/tests/jest/__snapshots__/ItemCollection.test.jsx.snap
+++ b/packages/terra-clinical-item-collection/tests/jest/__snapshots__/ItemCollection.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`test should render with a given breakpoint 1`] = `
 <ResponsiveElement
   defaultElement={
     <div
-      data-class="item-collection list-view">
+      data-terra-clinical-item-collection-list-view={true}>
       <SingleSelectList
         hasChevrons={false}
         isDivided={false}
@@ -116,7 +116,7 @@ exports[`test should render with a given breakpoint 1`] = `
   }
   medium={
     <div
-      data-class="item-collection table-view">
+      data-terra-clinical-item-collection-table-view={true}>
       <Table
         isPadded={true}
         isStriped={true}
@@ -160,21 +160,21 @@ exports[`test should render with a given breakpoint 1`] = `
                   isTruncated={false}
                   text="Display 1" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
                   text="Display 2" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
                   text="test comment" />
               }
-              data-class="content-comment" />
+              data-terra-clinical-item-collection-content="comment" />
             <TableCell
               className="content-accessory"
               content={
@@ -199,21 +199,21 @@ exports[`test should render with a given breakpoint 1`] = `
                   isTruncated={false}
                   text="Display 1" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
                   text="Display 2" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
                   text="test comment" />
               }
-              data-class="content-comment" />
+              data-terra-clinical-item-collection-content="comment" />
             <TableCell
               className="content-accessory"
               content={
@@ -238,21 +238,21 @@ exports[`test should render with a given breakpoint 1`] = `
                   isTruncated={false}
                   text="Display 1" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
                   text="Display 2" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
                   text="test comment" />
               }
-              data-class="content-comment" />
+              data-terra-clinical-item-collection-content="comment" />
             <TableCell
               className="content-accessory"
               content={
@@ -272,7 +272,7 @@ exports[`test should render with multiple rows 1`] = `
 <ResponsiveElement
   defaultElement={
     <div
-      data-class="item-collection list-view">
+      data-terra-clinical-item-collection-list-view={true}>
       <SingleSelectList
         hasChevrons={false}
         isDivided={false}
@@ -385,7 +385,7 @@ exports[`test should render with multiple rows 1`] = `
   responsiveTo="parent"
   small={
     <div
-      data-class="item-collection table-view">
+      data-terra-clinical-item-collection-table-view={true}>
       <Table
         isPadded={true}
         isStriped={true}
@@ -429,21 +429,21 @@ exports[`test should render with multiple rows 1`] = `
                   isTruncated={false}
                   text="Display 1" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
                   text="Display 2" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
                   text="test comment" />
               }
-              data-class="content-comment" />
+              data-terra-clinical-item-collection-content="comment" />
             <TableCell
               className="content-accessory"
               content={
@@ -468,21 +468,21 @@ exports[`test should render with multiple rows 1`] = `
                   isTruncated={false}
                   text="Display 1" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
                   text="Display 2" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
                   text="test comment" />
               }
-              data-class="content-comment" />
+              data-terra-clinical-item-collection-content="comment" />
             <TableCell
               className="content-accessory"
               content={
@@ -507,21 +507,21 @@ exports[`test should render with multiple rows 1`] = `
                   isTruncated={false}
                   text="Display 1" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
                   text="Display 2" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
                   text="test comment" />
               }
-              data-class="content-comment" />
+              data-terra-clinical-item-collection-content="comment" />
             <TableCell
               className="content-accessory"
               content={
@@ -540,7 +540,7 @@ exports[`test should render with one row 1`] = `
 <ResponsiveElement
   defaultElement={
     <div
-      data-class="item-collection list-view">
+      data-terra-clinical-item-collection-list-view={true}>
       <SingleSelectList
         hasChevrons={false}
         isDivided={false}
@@ -585,7 +585,7 @@ exports[`test should render with one row 1`] = `
   responsiveTo="parent"
   small={
     <div
-      data-class="item-collection table-view">
+      data-terra-clinical-item-collection-table-view={true}>
       <Table
         isPadded={true}
         isStriped={true}
@@ -629,21 +629,21 @@ exports[`test should render with one row 1`] = `
                   isTruncated={false}
                   text="Display 1" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
                   text="Display 2" />
               }
-              data-class="content-display" />
+              data-terra-clinical-item-collection-content="display" />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
                   text="test comment" />
               }
-              data-class="content-comment" />
+              data-terra-clinical-item-collection-content="comment" />
             <TableCell
               className="content-accessory"
               content={

--- a/packages/terra-clinical-item-collection/tests/jest/__snapshots__/TableHeaderCell.test.jsx.snap
+++ b/packages/terra-clinical-item-collection/tests/jest/__snapshots__/TableHeaderCell.test.jsx.snap
@@ -6,10 +6,10 @@ exports[`test should render accessory, comment and display table headers 1`] = `
       class="column-accessory"
       id="accessory" />
     <th
-      data-class="column-comment"
+      data-terra-clinical-item-collection-column="comment"
       id="comment" />
     <th
-      data-class="column-display"
+      data-terra-clinical-item-collection-column="display"
       id="display" />
   </tr>
 </thead>

--- a/packages/terra-clinical-item-collection/tests/nightwatch/item-collection/clinical-item-collection-spec.js
+++ b/packages/terra-clinical-item-collection/tests/nightwatch/item-collection/clinical-item-collection-spec.js
@@ -32,9 +32,9 @@ module.exports = {
     browser.execute("document.getElementById('siteApplication').style.padding = 0;");
 
     if (width < breakpoints.tiny) {
-      browser.assert.attributeEquals('#ItemCollection', 'data-class', 'item-collection list-view');
+      browser.expect.element('#ItemCollection').to.have.attribute('data-terra-clinical-item-collection-list-view');
     } else {
-      browser.assert.attributeEquals('#ItemCollection', 'data-class', 'item-collection table-view');
+      browser.expect.element('#ItemCollection').to.have.attribute('data-terra-clinical-item-collection-table-view');
     }
   },
 
@@ -44,9 +44,9 @@ module.exports = {
     browser.execute("document.getElementById('siteApplication').style.padding = 0;");
 
     if (width < breakpoints.small) {
-      browser.assert.attributeEquals('#ItemCollection', 'data-class', 'item-collection list-view');
+      browser.expect.element('#ItemCollection').to.have.attribute('data-terra-clinical-item-collection-list-view');
     } else {
-      browser.assert.attributeEquals('#ItemCollection', 'data-class', 'item-collection table-view');
+      browser.expect.element('#ItemCollection').to.have.attribute('data-terra-clinical-item-collection-table-view');
     }
   },
 
@@ -56,9 +56,9 @@ module.exports = {
     browser.execute("document.getElementById('siteApplication').style.padding = 0;");
 
     if (width < breakpoints.medium) {
-      browser.assert.attributeEquals('#ItemCollection', 'data-class', 'item-collection list-view');
+      browser.expect.element('#ItemCollection').to.have.attribute('data-terra-clinical-item-collection-list-view');
     } else {
-      browser.assert.attributeEquals('#ItemCollection', 'data-class', 'item-collection table-view');
+      browser.expect.element('#ItemCollection').to.have.attribute('data-terra-clinical-item-collection-table-view');
     }
   },
 
@@ -68,9 +68,9 @@ module.exports = {
     browser.execute("document.getElementById('siteApplication').style.padding = 0;");
 
     if (width < breakpoints.large) {
-      browser.assert.attributeEquals('#ItemCollection', 'data-class', 'item-collection list-view');
+      browser.expect.element('#ItemCollection').to.have.attribute('data-terra-clinical-item-collection-list-view');
     } else {
-      browser.assert.attributeEquals('#ItemCollection', 'data-class', 'item-collection table-view');
+      browser.expect.element('#ItemCollection').to.have.attribute('data-terra-clinical-item-collection-table-view');
     }
   },
 
@@ -80,9 +80,9 @@ module.exports = {
     browser.execute("document.getElementById('siteApplication').style.padding = 0;");
 
     if (width < breakpoints.huge) {
-      browser.assert.attributeEquals('#ItemCollection', 'data-class', 'item-collection list-view');
+      browser.expect.element('#ItemCollection').to.have.attribute('data-terra-clinical-item-collection-list-view');
     } else {
-      browser.assert.attributeEquals('#ItemCollection', 'data-class', 'item-collection table-view');
+      browser.expect.element('#ItemCollection').to.have.attribute('data-terra-clinical-item-collection-table-view');
     }
   },
 
@@ -157,7 +157,7 @@ module.exports = {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/item-collection-tests/varying-items`);
     browser.execute("document.getElementById('root').style.padding = 0;");
     if (width >= breakpoints.small) {
-      browser.assert.elementPresent('tr[class*="row"]:nth-child(4) > td[data-class*="content-comment"]:nth-child(5)');
+      browser.assert.elementPresent('tr[class*="row"]:nth-child(4) > td[data-terra-clinical-item-collection-content*="comment"]:nth-child(5)');
     }
   },
 
@@ -166,8 +166,8 @@ module.exports = {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/item-collection-tests/varying-items`);
     browser.execute("document.getElementById('root').style.padding = 0;");
     if (width >= breakpoints.small) {
-      browser.assert.elementPresent('tr[class*="row"]:nth-child(5) > td[data-class*="content-display"]:nth-child(3)');
-      browser.assert.elementPresent('tr[class*="row"]:nth-child(5) > td[data-class*="content-display"]:nth-child(4)');
+      browser.assert.elementPresent('tr[class*="row"]:nth-child(5) > td[data-terra-clinical-item-collection-content*="display"]:nth-child(3)');
+      browser.assert.elementPresent('tr[class*="row"]:nth-child(5) > td[data-terra-clinical-item-collection-content*="display"]:nth-child(4)');
     }
   },
 
@@ -176,8 +176,8 @@ module.exports = {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/item-collection-tests/varying-items`);
     browser.execute("document.getElementById('root').style.padding = 0;");
     if (width >= breakpoints.small) {
-      browser.assert.elementNotPresent('tr[class*="row"]:nth-child(6) > td[data-class*="content-display"]:nth-child(5)');
-      browser.assert.elementNotPresent('tr[class*="row"]:nth-child(6) > td[data-class*="content-display"]:nth-child(6)');
+      browser.assert.elementNotPresent('tr[class*="row"]:nth-child(6) > td[data-terra-clinical-item-collection-content*="display"]:nth-child(5)');
+      browser.assert.elementNotPresent('tr[class*="row"]:nth-child(6) > td[data-terra-clinical-item-collection-content*="display"]:nth-child(6)');
     }
   },
 
@@ -186,8 +186,8 @@ module.exports = {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/item-collection-tests/varying-items`);
     browser.execute("document.getElementById('root').style.padding = 0;");
     if (width >= breakpoints.small) {
-      browser.assert.elementPresent('tr[class*="row"]:nth-child(7) > td[data-class*="content-display"]:nth-child(4)');
-      browser.assert.elementPresent('tr[class*="row"]:nth-child(7) > td[data-class*="content-comment"]:nth-child(5)');
+      browser.assert.elementPresent('tr[class*="row"]:nth-child(7) > td[data-terra-clinical-item-collection-content*="display"]:nth-child(4)');
+      browser.assert.elementPresent('tr[class*="row"]:nth-child(7) > td[data-terra-clinical-item-collection-content*="comment"]:nth-child(5)');
       browser.assert.elementPresent('tr[class*="row"]:nth-child(7) > td[class*="content-accessory"]:nth-child(6)');
     }
   },

--- a/packages/terra-clinical-item-collection/tests/nightwatch/table-header-cell/table-header-cell-spec.js
+++ b/packages/terra-clinical-item-collection/tests/nightwatch/table-header-cell/table-header-cell-spec.js
@@ -14,8 +14,8 @@ module.exports = {
 
   'Displays the correct column class name': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/item-collection-table-header-cell-tests/examples`);
-    browser.assert.elementPresent('#accessory');
-    browser.assert.attributeEquals('#comment', 'data-class', 'column-comment');
-    browser.assert.attributeEquals('#display', 'data-class', 'column-display');
+    browser.expect.element('#accessory').to.be.present;
+    browser.expect.element('#comment').to.have.attribute('data-terra-clinical-item-collection-column').which.equals('comment');
+    browser.expect.element('#display').to.have.attribute('data-terra-clinical-item-collection-column').which.equals('display');
   },
 };

--- a/packages/terra-clinical-site/CHANGELOG.md
+++ b/packages/terra-clinical-site/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change data-class to be name spaced
 
 1.2.0 - (July 27, 2017)
 -----------------

--- a/packages/terra-clinical-site/src/App.jsx
+++ b/packages/terra-clinical-site/src/App.jsx
@@ -30,7 +30,7 @@ class App extends React.Component {
         <Grid>
           <Grid.Row>
             <Grid.Column small={2}>
-              <div data-class="directionality" dir="ltr">
+              <div data-terra-clinical-site-directionality dir="ltr">
                 <button onClick={() => document.getElementsByTagName('html')[0].setAttribute('dir', 'ltr')} >ltr</button>
                 <button onClick={() => document.getElementsByTagName('html')[0].setAttribute('dir', 'rtl')} >rtl</button>
               </div>


### PR DESCRIPTION
### Summary
In this closed PR https://github.com/cerner/terra-core/pull/694 it was discussed to change `data-class` attributes to be name spaced to the rendering component. This PR updates the ActionHeader, DetailList in DetailView, Item Collection and Site components to use name-spaced data attributes.

### Notes
The use of un-merged `data-class` attributes has caused Travis to recently fail for item-collection nightwatch tests. Item-collection uses terra-table and attempts to apply its own data-classes on different table components, however these are being overridden by table. With these name-spaced data attributes, this will no longer be an issue.

### More Information
Before the CSS Module conversion, some elements had terra class names to represent the structure of the component but did not apply any styling. In the conversion, the class names of un-styled elements were changed to data-class attributes to maintain this structural representation.

@cerner/terra
