### PR TITLE
Fix end aligned content with no text or left content.

### DIFF
--- a/packages/terra-clinical-header/CHANGELOG.md
+++ b/packages/terra-clinical-header/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Fixed
 * End aligned items with no title.
 
+### Added
+* isSubheader boolean prop to allow rendering of subheader component
+
 1.2.0 - (August 16, 2017)
 -----------------
 ### Fixed
@@ -14,9 +17,6 @@ Unreleased
 1.1.1 - (July 27, 2017)
 -----------------
 * Updated spacing around react-docgen comments
-
-### Added
-* isSubheader boolean prop to allow rendering of subheader component
 
 1.1.0 - (July 18, 2017)
 -----------------

--- a/packages/terra-clinical-header/CHANGELOG.md
+++ b/packages/terra-clinical-header/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Fixed
+* End aligned items with no title.
 
 1.2.0 - (August 16, 2017)
 -----------------

--- a/packages/terra-clinical-header/src/Header.jsx
+++ b/packages/terra-clinical-header/src/Header.jsx
@@ -35,15 +35,13 @@ const Header = ({ title, startContent, endContent, ...customProps }) => {
     startElement = <div className={cx('flexEnd')}>{startContent}</div>;
   }
 
-  let fillElement;
+  let titleElement;
   if (title) {
-    fillElement = (
-      <div className={cx('flexFill')}>
-        <div className={cx('titleContainer')}>
-          <h1 className={cx('title')}>
-            {title}
-          </h1>
-        </div>
+    titleElement = (
+      <div className={cx('titleContainer')}>
+        <h1 className={cx('title')}>
+          {title}
+        </h1>
       </div>
     );
   }
@@ -56,7 +54,9 @@ const Header = ({ title, startContent, endContent, ...customProps }) => {
   return (
     <header {...customProps} className={cx('flexHeader', customProps.className)}>
       {startElement}
-      {fillElement}
+      <div className={cx('flexFill')}>
+        {titleElement}
+      </div>
       {endElement}
     </header>
   );

--- a/packages/terra-clinical-header/tests/jest/__snapshots__/Header.test.jsx.snap
+++ b/packages/terra-clinical-header/tests/jest/__snapshots__/Header.test.jsx.snap
@@ -1,6 +1,9 @@
 exports[`test should render a default component 1`] = `
 <header
-  class="flexHeader" />
+  class="flexHeader">
+  <div
+    class="flexFill" />
+</header>
 `;
 
 exports[`test should render a header with all content 1`] = `
@@ -40,12 +43,16 @@ exports[`test should render a header with content on the left 1`] = `
       start content
     </div>
   </div>
+  <div
+    class="flexFill" />
 </header>
 `;
 
 exports[`test should render a header with content on the right 1`] = `
 <header
   class="flexHeader">
+  <div
+    class="flexFill" />
   <div
     class="flexEnd">
     <div>

--- a/packages/terra-clinical-header/tests/nightwatch/HeaderTestRoutes.jsx
+++ b/packages/terra-clinical-header/tests/nightwatch/HeaderTestRoutes.jsx
@@ -10,6 +10,7 @@ import RightContentHeader from './RightContentHeader';
 import LeftContentHeader from './LeftContentHeader';
 import LeftAndRightContentHeader from './LeftAndRightContentHeader';
 import LongTitleAndContentHeader from './LongTitleAndContentHeader';
+import NoTitleRightContentHeader from './NoTitleRightContentHeader';
 
 const routes = (
   <div>
@@ -21,6 +22,7 @@ const routes = (
     <Route path="/tests/header-tests/left-content" component={LeftContentHeader} />
     <Route path="/tests/header-tests/left-and-right-content" component={LeftAndRightContentHeader} />
     <Route path="/tests/header-tests/long-title-content" component={LongTitleAndContentHeader} />
+    <Route path="/tests/header-tests/no-title-right-content" component={NoTitleRightContentHeader} />
   </div>
 );
 

--- a/packages/terra-clinical-header/tests/nightwatch/HeaderTests.jsx
+++ b/packages/terra-clinical-header/tests/nightwatch/HeaderTests.jsx
@@ -13,6 +13,7 @@ const HeaderTests = () => (
       <li><Link to="/tests/header-tests/left-content">Header - Left Content</Link></li>
       <li><Link to="/tests/header-tests/left-and-right-content">Header - Left and Right Content</Link></li>
       <li><Link to="/tests/header-tests/long-title-content">Header - Long Title and Content</Link></li>
+      <li><Link to="/tests/header-tests/no-title-right-content">Header - No Title and RightContent</Link></li>
     </ul>
   </div>
 );

--- a/packages/terra-clinical-header/tests/nightwatch/NoTitleRightContentHeader.jsx
+++ b/packages/terra-clinical-header/tests/nightwatch/NoTitleRightContentHeader.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import Header from '../../lib/Header';
+
+const content = <div id="headerTest--content" style={{ backgroundColor: 'black', height: '30px', width: '300px', margin: '0 10px 0 0' }} />;
+
+export default () => (
+  <Header
+    endContent={content}
+  />
+);

--- a/packages/terra-clinical-header/tests/nightwatch/header-spec.js
+++ b/packages/terra-clinical-header/tests/nightwatch/header-spec.js
@@ -41,4 +41,8 @@ module.exports = {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/header-tests/long-title-content`)
     .assert.containsText('#Header h1', 'LongTitle');
   },
+  'Displays a header with no title and content on the right': (browser) => {
+    browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/header-tests/no-title-right-content`);
+    browser.expect.element('#headerTest--content').to.be.present;
+  },
 };

--- a/packages/terra-clinical-header/tests/nightwatch/header-spec.js
+++ b/packages/terra-clinical-header/tests/nightwatch/header-spec.js
@@ -46,7 +46,7 @@ module.exports = {
     .assert.elementPresent('header[class*="flexSubheader"]');
     browser.expect.element('#headerTest--startContent').to.be.present;
     browser.expect.element('#headerTest--endContent').to.be.present;
-  },  
+  },
   'Displays a header with no title and content on the right': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/header-tests/no-title-right-content`);
     browser.expect.element('#headerTest--content').to.be.present;

--- a/packages/terra-clinical-header/tests/nightwatch/header-spec.js
+++ b/packages/terra-clinical-header/tests/nightwatch/header-spec.js
@@ -46,6 +46,7 @@ module.exports = {
     .assert.elementPresent('header[class*="flexSubheader"]');
     browser.expect.element('#headerTest--startContent').to.be.present;
     browser.expect.element('#headerTest--endContent').to.be.present;
+  },  
   'Displays a header with no title and content on the right': (browser) => {
     browser.url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/header-tests/no-title-right-content`);
     browser.expect.element('#headerTest--content').to.be.present;


### PR DESCRIPTION
### Summary
Correct implementation for end aligned content when both the start aligned items and title is missing.

Fixes #183 

Deployment: https://terra-clinical-deployed-pr-182.herokuapp.com/static/#/site/header