### PR TITLE
Update components to use terra-base 2.0.0

### DIFF
--- a/packages/terra-clinical-action-header/CHANGELOG.md
+++ b/packages/terra-clinical-action-header/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change dependency on terra-base to v2.0.0
 
 1.2.0 - (August 16, 2017)
 -----------------

--- a/packages/terra-clinical-action-header/package.json
+++ b/packages/terra-clinical-action-header/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-button": "^1.0.0",
     "terra-button-group": "^1.0.0",
     "terra-clinical-header": "^1.3.0",
@@ -36,7 +36,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-button": "^1.0.0",
     "terra-button-group": "^1.0.0",
     "terra-clinical-header": "^1.3.0",

--- a/packages/terra-clinical-application-site/CHANGELOG.md
+++ b/packages/terra-clinical-application-site/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change dependency on terra-base to v2.0.0
 
 1.1.0 - (August 16, 2017)
 -----------------

--- a/packages/terra-clinical-application-site/package.json
+++ b/packages/terra-clinical-application-site/package.json
@@ -34,7 +34,7 @@
     "redux": "^3.6.0",
     "redux-saga": "^0.15.3",
     "terra-app-delegate": "^1.0.0",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-button": "^1.0.0",
     "terra-button-group": "^1.0.0",
     "terra-clinical-action-header": "^1.2.1",

--- a/packages/terra-clinical-application/CHANGELOG.md
+++ b/packages/terra-clinical-application/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change dependency on terra-base to v2.0.0
 
 1.1.1 - (July 27, 2017)
 -----------------

--- a/packages/terra-clinical-application/package.json
+++ b/packages/terra-clinical-application/package.json
@@ -28,12 +28,12 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "terra-app-delegate": "^1.0.0",
-    "terra-base": "^1.0.0"
+    "terra-base": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.0.0"
+    "terra-base": "^2.0.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-clinical-detail-view/CHANGELOG.md
+++ b/packages/terra-clinical-detail-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change dependency on terra-base to v2.0.0
 
 1.2.0 - (August 16, 2017)
 -----------------

--- a/packages/terra-clinical-detail-view/package.json
+++ b/packages/terra-clinical-detail-view/package.json
@@ -23,12 +23,12 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.0.0"
+    "terra-base": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.0.0"
+    "terra-base": "^2.0.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-clinical-detail-view/src/DetailView.scss
+++ b/packages/terra-clinical-detail-view/src/DetailView.scss
@@ -17,7 +17,6 @@
     font-size: 1.428rem;
     margin-bottom: 0;
     margin-top: 0;
-
   }
 
   .footer-text {

--- a/packages/terra-clinical-detail-view/src/DetailView.scss
+++ b/packages/terra-clinical-detail-view/src/DetailView.scss
@@ -15,7 +15,9 @@
 
   .primary-text {
     font-size: 1.428rem;
+    margin-bottom: 0;
     margin-top: 0;
+
   }
 
   .footer-text {

--- a/packages/terra-clinical-error-view/CHANGELOG.md
+++ b/packages/terra-clinical-error-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change dependency on terra-base to v2.0.0
 
 1.1.0 - (July 18, 2017)
 -----------------

--- a/packages/terra-clinical-error-view/package.json
+++ b/packages/terra-clinical-error-view/package.json
@@ -24,14 +24,14 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-button": "^1.0.0",
     "terra-icon": "^1.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-button": "^1.0.0",
     "terra-icon": "^1.0.0"
   },

--- a/packages/terra-clinical-error-view/src/ErrorView.scss
+++ b/packages/terra-clinical-error-view/src/ErrorView.scss
@@ -19,6 +19,8 @@
     flex: 0 0 auto;
     font-size: 1.7142857142857142rem;
     line-height: 1.284;
+    margin-bottom: 0;
+    margin-top: 0;
     text-align: center;
   }
 

--- a/packages/terra-clinical-header/CHANGELOG.md
+++ b/packages/terra-clinical-header/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change dependency on terra-base to v2.0.0
 
 1.3.0 - (August 22, 2017)
 -----------------

--- a/packages/terra-clinical-header/package.json
+++ b/packages/terra-clinical-header/package.json
@@ -24,12 +24,12 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.0.0"
+    "terra-base": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.0.0"
+    "terra-base": "^2.0.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-clinical-header/src/Header.scss
+++ b/packages/terra-clinical-header/src/Header.scss
@@ -43,6 +43,8 @@
     font-weight: normal;
     height: 100%;
     line-height: 1.75;
+    margin-bottom: 0;
+    margin-top: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/terra-clinical-item-collection/CHANGELOG.md
+++ b/packages/terra-clinical-item-collection/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change dependency on terra-base to v2.0.0
 
 1.2.0 - (August 16, 2017)
 -----------------

--- a/packages/terra-clinical-item-collection/package.json
+++ b/packages/terra-clinical-item-collection/package.json
@@ -23,12 +23,12 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.0.0"
+    "terra-base": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-clinical-item-view": "^1.2.2",
     "terra-list": "^1.0.0",
     "terra-responsive-element": "^1.0.0",

--- a/packages/terra-clinical-item-display/CHANGELOG.md
+++ b/packages/terra-clinical-item-display/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change dependency on terra-base to v2.0.0
 
 1.2.0 - (August 1, 2017)
 ----------

--- a/packages/terra-clinical-item-display/package.json
+++ b/packages/terra-clinical-item-display/package.json
@@ -24,13 +24,13 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-icon": "^1.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-icon": "^1.0.0"
   },
   "scripts": {

--- a/packages/terra-clinical-item-view/CHANGELOG.md
+++ b/packages/terra-clinical-item-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change dependency on terra-base to v2.0.0
 
 1.2.0 - (July 27, 2017)
 -----------------

--- a/packages/terra-clinical-item-view/package.json
+++ b/packages/terra-clinical-item-view/package.json
@@ -24,14 +24,14 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-clinical-item-display": "^1.2.1",
     "terra-icon": "^1.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-clinical-item-display": "^1.2.1",
     "terra-icon": "^1.0.0"
   },

--- a/packages/terra-clinical-label-value-view/CHANGELOG.md
+++ b/packages/terra-clinical-label-value-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change dependency on terra-base to v2.0.0
 
 1.1.0 - (July 18, 2017)
 -----------------

--- a/packages/terra-clinical-label-value-view/package.json
+++ b/packages/terra-clinical-label-value-view/package.json
@@ -24,12 +24,12 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.0.0"
+    "terra-base": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.0.0"
+    "terra-base": "^2.0.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-clinical-no-data-view/CHANGELOG.md
+++ b/packages/terra-clinical-no-data-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Change dependency on terra-base to v2.0.0
 
 1.1.0 - (July 18, 2017)
 -----------------

--- a/packages/terra-clinical-no-data-view/package.json
+++ b/packages/terra-clinical-no-data-view/package.json
@@ -24,13 +24,13 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-icon": "^1.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^1.0.0",
+    "terra-base": "^2.0.0",
     "terra-icon": "^1.0.0"
   },
   "scripts": {

--- a/packages/terra-clinical-no-data-view/src/NoDataView.scss
+++ b/packages/terra-clinical-no-data-view/src/NoDataView.scss
@@ -19,6 +19,8 @@
     flex: 0 0 auto;
     font-size: 1.7142857142857142rem;
     line-height: 1.284;
+    margin-bottom: 0;
+    margin-top: 0;
     text-align: center;
   }
 
@@ -27,6 +29,8 @@
     flex: 0 0 auto;
     font-size: 1rem;
     line-height: 1.142;
+    margin-bottom: 0;
+    margin-top: 0;
     padding-top: 0.2857rem;
     text-align: center;
   }


### PR DESCRIPTION
### Summary
Updating all components that had a dependency on base to use terra-base@2.0.0.
Added margin resets to elements used in clinical components which used to have margin reset in terra-base@1.0.0

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
