### PR TITLE
Update jest to v21.0.2

### DIFF
--- a/jestconfig.json
+++ b/jestconfig.json
@@ -1,9 +1,9 @@
 {
   "setupFiles": [
-    "../../jestsetup.js"
+    "./jestsetup.js"
   ],
   "snapshotSerializers": [
-    "../../node_modules/enzyme-to-json/serializer"
+    "./node_modules/enzyme-to-json/serializer"
   ],
   "moduleNameMapper": {
     "\\.(css|scss)$": "identity-obj-proxy"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-react": "^6.9.0",
     "express": "^4.15.2",
     "identity-obj-proxy": "^3.0.0",
-    "jest": "^18.0.0",
+    "jest": "^21.0.2",
     "lerna": "2.0.0-rc.4",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/packages/terra-clinical-action-header/package.json
+++ b/packages/terra-clinical-action-header/package.json
@@ -52,7 +52,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "$(cd ..; npm bin)/props-table ./src/ActionHeader.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-clinical-action-header/tests/jest/__snapshots__/ActionHeader.test.jsx.snap
+++ b/packages/terra-clinical-action-header/tests/jest/__snapshots__/ActionHeader.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render ActionHeader with Previous-Next button when onNext is givien 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render ActionHeader with Previous-Next button when onNext is givien 1`] = `
 <ActionHeader
   onBack={null}
   onClose={null}
@@ -6,10 +8,11 @@ exports[`test should render ActionHeader with Previous-Next button when onNext i
   onMinimize={null}
   onNext={[Function]}
   onPrevious={null}
-  title="" />
+  title=""
+/>
 `;
 
-exports[`test should render ActionHeader with Previous-Next button when onPrevious is givien 1`] = `
+exports[`should render ActionHeader with Previous-Next button when onPrevious is givien 1`] = `
 <ActionHeader
   onBack={null}
   onClose={null}
@@ -17,10 +20,11 @@ exports[`test should render ActionHeader with Previous-Next button when onPrevio
   onMinimize={null}
   onNext={null}
   onPrevious={[Function]}
-  title="" />
+  title=""
+/>
 `;
 
-exports[`test should render ActionHeader with back button 1`] = `
+exports[`should render ActionHeader with back button 1`] = `
 <ActionHeader
   onBack={[Function]}
   onClose={null}
@@ -28,10 +32,11 @@ exports[`test should render ActionHeader with back button 1`] = `
   onMinimize={null}
   onNext={null}
   onPrevious={null}
-  title="" />
+  title=""
+/>
 `;
 
-exports[`test should render ActionHeader with children 1`] = `
+exports[`should render ActionHeader with children 1`] = `
 <ActionHeader
   onBack={null}
   onClose={null}
@@ -39,18 +44,20 @@ exports[`test should render ActionHeader with children 1`] = `
   onMinimize={null}
   onNext={null}
   onPrevious={null}
-  title="">
+  title=""
+>
   <Button
     isBlock={false}
     isCompact={false}
     isDisabled={false}
     isReversed={false}
     type="button"
-    variant="default" />
+    variant="default"
+  />
 </ActionHeader>
 `;
 
-exports[`test should render ActionHeader with close button 1`] = `
+exports[`should render ActionHeader with close button 1`] = `
 <ActionHeader
   onBack={null}
   onClose={[Function]}
@@ -58,10 +65,11 @@ exports[`test should render ActionHeader with close button 1`] = `
   onMinimize={null}
   onNext={null}
   onPrevious={null}
-  title="" />
+  title=""
+/>
 `;
 
-exports[`test should render ActionHeader with expand button 1`] = `
+exports[`should render ActionHeader with expand button 1`] = `
 <ActionHeader
   onBack={null}
   onClose={null}
@@ -69,10 +77,11 @@ exports[`test should render ActionHeader with expand button 1`] = `
   onMinimize={null}
   onNext={null}
   onPrevious={null}
-  title="" />
+  title=""
+/>
 `;
 
-exports[`test should render ActionHeader with minimize button 1`] = `
+exports[`should render ActionHeader with minimize button 1`] = `
 <ActionHeader
   onBack={null}
   onClose={null}
@@ -80,10 +89,11 @@ exports[`test should render ActionHeader with minimize button 1`] = `
   onMinimize={[Function]}
   onNext={null}
   onPrevious={null}
-  title="" />
+  title=""
+/>
 `;
 
-exports[`test should render ActionHeader with title 1`] = `
+exports[`should render ActionHeader with title 1`] = `
 <ActionHeader
   onBack={null}
   onClose={null}
@@ -91,10 +101,11 @@ exports[`test should render ActionHeader with title 1`] = `
   onMinimize={null}
   onNext={null}
   onPrevious={null}
-  title="Title" />
+  title="Title"
+/>
 `;
 
-exports[`test should render default component 1`] = `
+exports[`should render default component 1`] = `
 <ActionHeader
   onBack={null}
   onClose={null}
@@ -102,5 +113,6 @@ exports[`test should render default component 1`] = `
   onMinimize={null}
   onNext={null}
   onPrevious={null}
-  title="" />
+  title=""
+/>
 `;

--- a/packages/terra-clinical-application/package.json
+++ b/packages/terra-clinical-application/package.json
@@ -44,7 +44,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "$(cd ..; npm bin)/props-table ./src/Application.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-clinical-application/tests/jest/__snapshots__/Application.test.jsx.snap
+++ b/packages/terra-clinical-application/tests/jest/__snapshots__/Application.test.jsx.snap
@@ -1,29 +1,35 @@
-exports[`test should render children with app prop 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render children with app prop 1`] = `
 <Base
   className="application"
-  customMessages={Object {}}>
+  customMessages={Object {}}
+>
   <div
-    app={AppDelegateInstance {}}>
+    app={AppDelegateInstance {}}
+  >
     TestApp
   </div>
 </Base>
 `;
 
-exports[`test should render custom properties on component 1`] = `
+exports[`should render custom properties on component 1`] = `
 <Base
   className="application custom-class"
   customMessages={Object {}}
-  id="my-id">
+  id="my-id"
+>
   <div>
     TestApp
   </div>
 </Base>
 `;
 
-exports[`test should render default component 1`] = `
+exports[`should render default component 1`] = `
 <Base
   className="application"
-  customMessages={Object {}}>
+  customMessages={Object {}}
+>
   <div>
     TestApp
   </div>

--- a/packages/terra-clinical-detail-view/package.json
+++ b/packages/terra-clinical-detail-view/package.json
@@ -39,7 +39,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "$(cd ..; npm bin)/props-table ./src/DetailList.jsx ./src/DetailListItem.jsx ./src/DetailView.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailList.test.jsx.snap
+++ b/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailList.test.jsx.snap
@@ -1,24 +1,32 @@
-exports[`test should render a default component 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default component 1`] = `
 <div
-  data-terra-clincial-detail-list="true">
+  data-terra-clincial-detail-list="true"
+>
   <div
-    class="list" />
+    class="list"
+  />
 </div>
 `;
 
-exports[`test should render a list 1`] = `
+exports[`should render a list 1`] = `
 <div
-  data-terra-clincial-detail-list="true">
+  data-terra-clincial-detail-list="true"
+>
   <div
-    class="list">
+    class="list"
+  >
     <div
-      class="detail-list-item">
+      class="detail-list-item"
+    >
       <p>
         Test
       </p>
     </div>
     <div
-      class="detail-list-item">
+      class="detail-list-item"
+    >
       <p>
         Test
       </p>
@@ -27,29 +35,36 @@ exports[`test should render a list 1`] = `
 </div>
 `;
 
-exports[`test should render a title 1`] = `
+exports[`should render a title 1`] = `
 <div
-  data-terra-clincial-detail-list="true">
+  data-terra-clincial-detail-list="true"
+>
   <div
-    class="title">
+    class="title"
+  >
     Title
   </div>
   <div
-    class="list" />
+    class="list"
+  />
 </div>
 `;
 
-exports[`test should render a title and a list 1`] = `
+exports[`should render a title and a list 1`] = `
 <div
-  data-terra-clincial-detail-list="true">
+  data-terra-clincial-detail-list="true"
+>
   <div
-    class="title">
+    class="title"
+  >
     Title
   </div>
   <div
-    class="list">
+    class="list"
+  >
     <div
-      class="detail-list-item">
+      class="detail-list-item"
+    >
       <p>
         Test
       </p>

--- a/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailListItem.test.jsx.snap
+++ b/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailListItem.test.jsx.snap
@@ -1,6 +1,9 @@
-exports[`test should render a default component 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default component 1`] = `
 <div
-  class="detail-list-item">
+  class="detail-list-item"
+>
   <p>
     Test
   </p>

--- a/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailView.test.jsx.snap
+++ b/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailView.test.jsx.snap
@@ -1,167 +1,215 @@
-exports[`test should render a default component 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default component 1`] = `
 <div
-  class="detail-view">
+  class="detail-view"
+>
   <div
-    class="title">
+    class="title"
+  >
     <h1
-      class="primary-text" />
+      class="primary-text"
+    />
   </div>
   <hr
-    class="divider" />
+    class="divider"
+  />
   <div
-    class="footer-text" />
+    class="footer-text"
+  />
 </div>
 `;
 
-exports[`test should render a title 1`] = `
+exports[`should render a title 1`] = `
 <div
-  class="detail-view">
+  class="detail-view"
+>
   <div
-    class="title">
+    class="title"
+  >
     <h1
-      class="primary-text">
+      class="primary-text"
+    >
       Header
     </h1>
   </div>
   <hr
-    class="divider" />
+    class="divider"
+  />
   <div
-    class="footer-text" />
+    class="footer-text"
+  />
 </div>
 `;
 
-exports[`test should render details 1`] = `
+exports[`should render details 1`] = `
 <div
-  class="detail-view">
+  class="detail-view"
+>
   <div
-    class="title">
+    class="title"
+  >
     <h1
-      class="primary-text">
+      class="primary-text"
+    >
       Header
     </h1>
     <div
-      class="subtitle">
+      class="subtitle"
+    >
       Subtitle 1
     </div>
     <div
-      class="subtitle">
+      class="subtitle"
+    >
       Subtitle 2
     </div>
   </div>
   <hr
-    class="divider" />
+    class="divider"
+  />
   <p>
      Detail information 
   </p>
   <hr
-    class="divider" />
+    class="divider"
+  />
   <div
-    class="footer-text" />
+    class="footer-text"
+  />
 </div>
 `;
 
-exports[`test should render footer 1`] = `
+exports[`should render footer 1`] = `
 <div
-  class="detail-view">
+  class="detail-view"
+>
   <div
-    class="title">
+    class="title"
+  >
     <h1
-      class="primary-text">
+      class="primary-text"
+    >
       Header
     </h1>
     <div
-      class="subtitle">
+      class="subtitle"
+    >
       Subtitle 1
     </div>
     <div
-      class="subtitle">
+      class="subtitle"
+    >
       Subtitle 2
     </div>
   </div>
   <hr
-    class="divider" />
+    class="divider"
+  />
   <p>
      Detail information 
   </p>
   <hr
-    class="divider" />
+    class="divider"
+  />
   <div
-    class="footer-text">
+    class="footer-text"
+  >
     Footer text
   </div>
 </div>
 `;
 
-exports[`test should render graph 1`] = `
+exports[`should render graph 1`] = `
 <div
-  class="detail-view">
+  class="detail-view"
+>
   <div
-    class="title">
+    class="title"
+  >
     <h1
-      class="primary-text">
+      class="primary-text"
+    >
       Header
     </h1>
     <div
-      class="subtitle">
+      class="subtitle"
+    >
       Subtitle 1
     </div>
     <div
-      class="subtitle">
+      class="subtitle"
+    >
       Subtitle 2
     </div>
   </div>
   <hr
-    class="divider" />
+    class="divider"
+  />
   <div>
      This is where a graph would go 
   </div>
   <hr
-    class="divider" />
+    class="divider"
+  />
   <div
-    class="footer-text" />
+    class="footer-text"
+  />
 </div>
 `;
 
-exports[`test should render subtitles 1`] = `
+exports[`should render subtitles 1`] = `
 <div
-  class="detail-view">
+  class="detail-view"
+>
   <div
-    class="title">
+    class="title"
+  >
     <h1
-      class="primary-text">
+      class="primary-text"
+    >
       Header
     </h1>
     <div
-      class="subtitle">
+      class="subtitle"
+    >
       Subtitle 1
     </div>
     <div
-      class="subtitle">
+      class="subtitle"
+    >
       Subtitle 2
     </div>
   </div>
   <hr
-    class="divider" />
+    class="divider"
+  />
   <div
-    class="footer-text" />
+    class="footer-text"
+  />
 </div>
 `;
 
-exports[`test should render without a divider when indicated 1`] = `
+exports[`should render without a divider when indicated 1`] = `
 <div
-  class="detail-view">
+  class="detail-view"
+>
   <div
-    class="title">
+    class="title"
+  >
     <h1
-      class="primary-text">
+      class="primary-text"
+    >
       Header
     </h1>
     <div
-      class="subtitle">
+      class="subtitle"
+    >
       Subtitle 1
     </div>
     <div
-      class="subtitle">
+      class="subtitle"
+    >
       Subtitle 2
     </div>
   </div>
@@ -169,7 +217,8 @@ exports[`test should render without a divider when indicated 1`] = `
      Detail information 
   </p>
   <div
-    class="footer-text">
+    class="footer-text"
+  >
     Footer text
   </div>
 </div>

--- a/packages/terra-clinical-error-view/package.json
+++ b/packages/terra-clinical-error-view/package.json
@@ -44,7 +44,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "$(cd ..; npm bin)/props-table ./src/ErrorView.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-clinical-error-view/tests/jest/__snapshots__/ErrorView.test.jsx.snap
+++ b/packages/terra-clinical-error-view/tests/jest/__snapshots__/ErrorView.test.jsx.snap
@@ -1,22 +1,30 @@
-exports[`test should not render a glyph 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should not render a glyph 1`] = `
 <div
-  class="error-view">
+  class="error-view"
+>
   <p
-    class="text" />
+    class="text"
+  />
 </div>
 `;
 
-exports[`test should render a button with text 1`] = `
+exports[`should render a button with text 1`] = `
 <div
-  className="error-view">
+  className="error-view"
+>
   <div
-    className="glyph">
+    className="glyph"
+  >
     <ErrorIcon />
   </div>
   <p
-    className="text" />
+    className="text"
+  />
   <div
-    className="button">
+    className="button"
+  >
     <Button
       isBlock={false}
       isCompact={false}
@@ -25,73 +33,89 @@ exports[`test should render a button with text 1`] = `
       onClick={[Function]}
       text="test button text"
       type="button"
-      variant="secondary" />
+      variant="secondary"
+    />
   </div>
 </div>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a default component 1`] = `
 <div
-  class="error-view">
+  class="error-view"
+>
   <div
-    class="glyph">
+    class="glyph"
+  >
     <svg
       data-name="Layer 1"
       height="170px"
       id="Layer_1"
       viewbox="0 0 251.7 251.8"
-      width="170px">
+      width="170px"
+    >
       <path
         d="M125.9,0C56.1,0,0,56.2,0,125.9s56,125.9,125.8,125.9s125.9-56.1,125.9-125.9S195.6,0,125.9,0z M36.7,139 v-26.2H215V139H36.7z"
-        style="fill:#e8e9ea;" />
+        style="fill:#e8e9ea;"
+      />
     </svg>
   </div>
   <p
-    class="text" />
+    class="text"
+  />
 </div>
 `;
 
-exports[`test should render a description 1`] = `
+exports[`should render a description 1`] = `
 <div
-  class="error-view">
+  class="error-view"
+>
   <div
-    class="glyph">
+    class="glyph"
+  >
     <svg
       data-name="Layer 1"
       height="170px"
       id="Layer_1"
       viewbox="0 0 251.7 251.8"
-      width="170px">
+      width="170px"
+    >
       <path
         d="M125.9,0C56.1,0,0,56.2,0,125.9s56,125.9,125.8,125.9s125.9-56.1,125.9-125.9S195.6,0,125.9,0z M36.7,139 v-26.2H215V139H36.7z"
-        style="fill:#e8e9ea;" />
+        style="fill:#e8e9ea;"
+      />
     </svg>
   </div>
   <p
-    class="text">
+    class="text"
+  >
     test description.
   </p>
 </div>
 `;
 
-exports[`test should render a name 1`] = `
+exports[`should render a name 1`] = `
 <div
-  class="error-view">
+  class="error-view"
+>
   <div
-    class="glyph">
+    class="glyph"
+  >
     <svg
       data-name="Layer 1"
       height="170px"
       id="Layer_1"
       viewbox="0 0 251.7 251.8"
-      width="170px">
+      width="170px"
+    >
       <path
         d="M125.9,0C56.1,0,0,56.2,0,125.9s56,125.9,125.8,125.9s125.9-56.1,125.9-125.9S195.6,0,125.9,0z M36.7,139 v-26.2H215V139H36.7z"
-        style="fill:#e8e9ea;" />
+        style="fill:#e8e9ea;"
+      />
     </svg>
   </div>
   <p
-    class="text">
+    class="text"
+  >
     <b>
       test error name:
     </b>

--- a/packages/terra-clinical-header/package.json
+++ b/packages/terra-clinical-header/package.json
@@ -40,7 +40,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "$(cd ..; npm bin)/props-table ./src/Header.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-clinical-header/tests/jest/__snapshots__/Header.test.jsx.snap
+++ b/packages/terra-clinical-header/tests/jest/__snapshots__/Header.test.jsx.snap
@@ -1,32 +1,42 @@
-exports[`test should render a default component 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default component 1`] = `
 <header
-  class="flexHeader">
+  class="flexHeader"
+>
   <div
-    class="flexFill" />
+    class="flexFill"
+  />
 </header>
 `;
 
-exports[`test should render a header with all content 1`] = `
+exports[`should render a header with all content 1`] = `
 <header
-  class="flexHeader">
+  class="flexHeader"
+>
   <div
-    class="flexEnd">
+    class="flexEnd"
+  >
     <div>
       start content
     </div>
   </div>
   <div
-    class="flexFill">
+    class="flexFill"
+  >
     <div
-      class="titleContainer">
+      class="titleContainer"
+    >
       <h1
-        class="title">
+        class="title"
+      >
         Title
       </h1>
     </div>
   </div>
   <div
-    class="flexEnd">
+    class="flexEnd"
+  >
     <div>
       end content
     </div>
@@ -34,27 +44,33 @@ exports[`test should render a header with all content 1`] = `
 </header>
 `;
 
-exports[`test should render a header with content on the left 1`] = `
+exports[`should render a header with content on the left 1`] = `
 <header
-  class="flexHeader">
+  class="flexHeader"
+>
   <div
-    class="flexEnd">
+    class="flexEnd"
+  >
     <div>
       start content
     </div>
   </div>
   <div
-    class="flexFill" />
+    class="flexFill"
+  />
 </header>
 `;
 
-exports[`test should render a header with content on the right 1`] = `
+exports[`should render a header with content on the right 1`] = `
 <header
-  class="flexHeader">
+  class="flexHeader"
+>
   <div
-    class="flexFill" />
+    class="flexFill"
+  />
   <div
-    class="flexEnd">
+    class="flexEnd"
+  >
     <div>
       end content
     </div>
@@ -62,15 +78,19 @@ exports[`test should render a header with content on the right 1`] = `
 </header>
 `;
 
-exports[`test should render a header with title only 1`] = `
+exports[`should render a header with title only 1`] = `
 <header
-  class="flexHeader">
+  class="flexHeader"
+>
   <div
-    class="flexFill">
+    class="flexFill"
+  >
     <div
-      class="titleContainer">
+      class="titleContainer"
+    >
       <h1
-        class="title">
+        class="title"
+      >
         title
       </h1>
     </div>
@@ -78,27 +98,33 @@ exports[`test should render a header with title only 1`] = `
 </header>
 `;
 
-exports[`test should render a subheader with all content 1`] = `
+exports[`should render a subheader with all content 1`] = `
 <header
-  class="flexSubheader">
+  class="flexSubheader"
+>
   <div
-    class="flexEnd">
+    class="flexEnd"
+  >
     <div>
       start content
     </div>
   </div>
   <div
-    class="flexFill">
+    class="flexFill"
+  >
     <div
-      class="titleContainer">
+      class="titleContainer"
+    >
       <h1
-        class="title">
+        class="title"
+      >
         Title
       </h1>
     </div>
   </div>
   <div
-    class="flexEnd">
+    class="flexEnd"
+  >
     <div>
       end content
     </div>
@@ -106,15 +132,19 @@ exports[`test should render a subheader with all content 1`] = `
 </header>
 `;
 
-exports[`test should render a subheader with title only 1`] = `
+exports[`should render a subheader with title only 1`] = `
 <header
-  class="flexSubheader">
+  class="flexSubheader"
+>
   <div
-    class="flexFill">
+    class="flexFill"
+  >
     <div
-      class="titleContainer">
+      class="titleContainer"
+    >
       <h1
-        class="title">
+        class="title"
+      >
         title
       </h1>
     </div>

--- a/packages/terra-clinical-item-collection/package.json
+++ b/packages/terra-clinical-item-collection/package.json
@@ -43,7 +43,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "$(cd ..; npm bin)/props-table ./src/ItemCollection.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-clinical-item-collection/tests/jest/__snapshots__/ItemCollection.test.jsx.snap
+++ b/packages/terra-clinical-item-collection/tests/jest/__snapshots__/ItemCollection.test.jsx.snap
@@ -1,14 +1,18 @@
-exports[`test should render a default component 1`] = `null`;
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test should render with a given breakpoint 1`] = `
+exports[`should render a default component 1`] = `null`;
+
+exports[`should render with a given breakpoint 1`] = `
 <ResponsiveElement
   defaultElement={
     <div
-      data-terra-clinical-item-collection-list-view={true}>
+      data-terra-clinical-item-collection-list-view={true}
+    >
       <SingleSelectList
         hasChevrons={false}
         isDivided={false}
-        onChange={[Function]}>
+        onChange={[Function]}
+      >
         <ListItem
           content={
             <ItemView
@@ -16,16 +20,19 @@ exports[`test should render with a given breakpoint 1`] = `
               comment={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
               displays={
                 Array [
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 1" />,
+                    text="Display 1"
+                  />,
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 2" />,
+                    text="Display 2"
+                  />,
                 ]
               }
               endAccessory={
@@ -40,9 +47,11 @@ exports[`test should render with a given breakpoint 1`] = `
                   Start Accessory
                 </p>
               }
-              textEmphasis="default" />
+              textEmphasis="default"
+            />
           }
-          isSelected={false} />
+          isSelected={false}
+        />
         <ListItem
           content={
             <ItemView
@@ -50,16 +59,19 @@ exports[`test should render with a given breakpoint 1`] = `
               comment={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
               displays={
                 Array [
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 1" />,
+                    text="Display 1"
+                  />,
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 2" />,
+                    text="Display 2"
+                  />,
                 ]
               }
               endAccessory={
@@ -74,9 +86,11 @@ exports[`test should render with a given breakpoint 1`] = `
                   Start Accessory
                 </p>
               }
-              textEmphasis="default" />
+              textEmphasis="default"
+            />
           }
-          isSelected={false} />
+          isSelected={false}
+        />
         <ListItem
           content={
             <ItemView
@@ -84,16 +98,19 @@ exports[`test should render with a given breakpoint 1`] = `
               comment={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
               displays={
                 Array [
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 1" />,
+                    text="Display 1"
+                  />,
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 2" />,
+                    text="Display 2"
+                  />,
                 ]
               }
               endAccessory={
@@ -108,15 +125,18 @@ exports[`test should render with a given breakpoint 1`] = `
                   Start Accessory
                 </p>
               }
-              textEmphasis="default" />
+              textEmphasis="default"
+            />
           }
-          isSelected={false} />
+          isSelected={false}
+        />
       </SingleSelectList>
     </div>
   }
   medium={
     <div
-      data-terra-clinical-item-collection-table-view={true}>
+      data-terra-clinical-item-collection-table-view={true}
+    >
       <Table
         isPadded={true}
         isStriped={true}
@@ -124,159 +144,197 @@ exports[`test should render with a given breakpoint 1`] = `
           Object {
             "tableLayout": "fixed",
           }
-        }>
+        }
+      >
         <TableHeader
           style={
             Object {
               "visibility": "hidden",
             }
-          }>
+          }
+        >
           <TableHeaderCell
-            columnType="accessory" />
+            columnType="accessory"
+          />
           <TableHeaderCell
-            columnType="display" />
+            columnType="display"
+          />
           <TableHeaderCell
-            columnType="display" />
+            columnType="display"
+          />
           <TableHeaderCell
-            columnType="comment" />
+            columnType="comment"
+          />
           <TableHeaderCell
-            columnType="accessory" />
+            columnType="accessory"
+          />
         </TableHeader>
         <SingleSelectableRows
-          onChange={[Function]}>
+          onChange={[Function]}
+        >
           <TableRow
             isSelectable={true}
-            isSelected={false}>
+            isSelected={false}
+          >
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   Start Accessory
                 </p>
-              } />
+              }
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 1" />
+                  text="Display 1"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 2" />
+                  text="Display 2"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
-              data-terra-clinical-item-collection-content="comment" />
+              data-terra-clinical-item-collection-content="comment"
+            />
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   End Accessory
                 </p>
-              } />
+              }
+            />
           </TableRow>
           <TableRow
             isSelectable={true}
-            isSelected={false}>
+            isSelected={false}
+          >
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   Start Accessory
                 </p>
-              } />
+              }
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 1" />
+                  text="Display 1"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 2" />
+                  text="Display 2"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
-              data-terra-clinical-item-collection-content="comment" />
+              data-terra-clinical-item-collection-content="comment"
+            />
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   End Accessory
                 </p>
-              } />
+              }
+            />
           </TableRow>
           <TableRow
             isSelectable={true}
-            isSelected={false}>
+            isSelected={false}
+          >
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   Start Accessory
                 </p>
-              } />
+              }
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 1" />
+                  text="Display 1"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 2" />
+                  text="Display 2"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
-              data-terra-clinical-item-collection-content="comment" />
+              data-terra-clinical-item-collection-content="comment"
+            />
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   End Accessory
                 </p>
-              } />
+              }
+            />
           </TableRow>
         </SingleSelectableRows>
       </Table>
     </div>
   }
-  responsiveTo="parent" />
+  responsiveTo="parent"
+/>
 `;
 
-exports[`test should render with multiple rows 1`] = `
+exports[`should render with multiple rows 1`] = `
 <ResponsiveElement
   defaultElement={
     <div
-      data-terra-clinical-item-collection-list-view={true}>
+      data-terra-clinical-item-collection-list-view={true}
+    >
       <SingleSelectList
         hasChevrons={false}
         isDivided={false}
-        onChange={[Function]}>
+        onChange={[Function]}
+      >
         <ListItem
           content={
             <ItemView
@@ -284,16 +342,19 @@ exports[`test should render with multiple rows 1`] = `
               comment={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
               displays={
                 Array [
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 1" />,
+                    text="Display 1"
+                  />,
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 2" />,
+                    text="Display 2"
+                  />,
                 ]
               }
               endAccessory={
@@ -308,9 +369,11 @@ exports[`test should render with multiple rows 1`] = `
                   Start Accessory
                 </p>
               }
-              textEmphasis="default" />
+              textEmphasis="default"
+            />
           }
-          isSelected={false} />
+          isSelected={false}
+        />
         <ListItem
           content={
             <ItemView
@@ -318,16 +381,19 @@ exports[`test should render with multiple rows 1`] = `
               comment={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
               displays={
                 Array [
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 1" />,
+                    text="Display 1"
+                  />,
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 2" />,
+                    text="Display 2"
+                  />,
                 ]
               }
               endAccessory={
@@ -342,9 +408,11 @@ exports[`test should render with multiple rows 1`] = `
                   Start Accessory
                 </p>
               }
-              textEmphasis="default" />
+              textEmphasis="default"
+            />
           }
-          isSelected={false} />
+          isSelected={false}
+        />
         <ListItem
           content={
             <ItemView
@@ -352,16 +420,19 @@ exports[`test should render with multiple rows 1`] = `
               comment={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
               displays={
                 Array [
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 1" />,
+                    text="Display 1"
+                  />,
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 2" />,
+                    text="Display 2"
+                  />,
                 ]
               }
               endAccessory={
@@ -376,16 +447,19 @@ exports[`test should render with multiple rows 1`] = `
                   Start Accessory
                 </p>
               }
-              textEmphasis="default" />
+              textEmphasis="default"
+            />
           }
-          isSelected={false} />
+          isSelected={false}
+        />
       </SingleSelectList>
     </div>
   }
   responsiveTo="parent"
   small={
     <div
-      data-terra-clinical-item-collection-table-view={true}>
+      data-terra-clinical-item-collection-table-view={true}
+    >
       <Table
         isPadded={true}
         isStriped={true}
@@ -393,158 +467,196 @@ exports[`test should render with multiple rows 1`] = `
           Object {
             "tableLayout": "fixed",
           }
-        }>
+        }
+      >
         <TableHeader
           style={
             Object {
               "visibility": "hidden",
             }
-          }>
+          }
+        >
           <TableHeaderCell
-            columnType="accessory" />
+            columnType="accessory"
+          />
           <TableHeaderCell
-            columnType="display" />
+            columnType="display"
+          />
           <TableHeaderCell
-            columnType="display" />
+            columnType="display"
+          />
           <TableHeaderCell
-            columnType="comment" />
+            columnType="comment"
+          />
           <TableHeaderCell
-            columnType="accessory" />
+            columnType="accessory"
+          />
         </TableHeader>
         <SingleSelectableRows
-          onChange={[Function]}>
+          onChange={[Function]}
+        >
           <TableRow
             isSelectable={true}
-            isSelected={false}>
+            isSelected={false}
+          >
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   Start Accessory
                 </p>
-              } />
+              }
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 1" />
+                  text="Display 1"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 2" />
+                  text="Display 2"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
-              data-terra-clinical-item-collection-content="comment" />
+              data-terra-clinical-item-collection-content="comment"
+            />
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   End Accessory
                 </p>
-              } />
+              }
+            />
           </TableRow>
           <TableRow
             isSelectable={true}
-            isSelected={false}>
+            isSelected={false}
+          >
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   Start Accessory
                 </p>
-              } />
+              }
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 1" />
+                  text="Display 1"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 2" />
+                  text="Display 2"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
-              data-terra-clinical-item-collection-content="comment" />
+              data-terra-clinical-item-collection-content="comment"
+            />
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   End Accessory
                 </p>
-              } />
+              }
+            />
           </TableRow>
           <TableRow
             isSelectable={true}
-            isSelected={false}>
+            isSelected={false}
+          >
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   Start Accessory
                 </p>
-              } />
+              }
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 1" />
+                  text="Display 1"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 2" />
+                  text="Display 2"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
-              data-terra-clinical-item-collection-content="comment" />
+              data-terra-clinical-item-collection-content="comment"
+            />
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   End Accessory
                 </p>
-              } />
+              }
+            />
           </TableRow>
         </SingleSelectableRows>
       </Table>
     </div>
-  } />
+  }
+/>
 `;
 
-exports[`test should render with one row 1`] = `
+exports[`should render with one row 1`] = `
 <ResponsiveElement
   defaultElement={
     <div
-      data-terra-clinical-item-collection-list-view={true}>
+      data-terra-clinical-item-collection-list-view={true}
+    >
       <SingleSelectList
         hasChevrons={false}
         isDivided={false}
-        onChange={[Function]}>
+        onChange={[Function]}
+      >
         <ListItem
           content={
             <ItemView
@@ -552,16 +664,19 @@ exports[`test should render with one row 1`] = `
               comment={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
               displays={
                 Array [
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 1" />,
+                    text="Display 1"
+                  />,
                   <ItemDisplay
                     isTruncated={false}
-                    text="Display 2" />,
+                    text="Display 2"
+                  />,
                 ]
               }
               endAccessory={
@@ -576,16 +691,19 @@ exports[`test should render with one row 1`] = `
                   Start Accessory
                 </p>
               }
-              textEmphasis="default" />
+              textEmphasis="default"
+            />
           }
-          isSelected={false} />
+          isSelected={false}
+        />
       </SingleSelectList>
     </div>
   }
   responsiveTo="parent"
   small={
     <div
-      data-terra-clinical-item-collection-table-view={true}>
+      data-terra-clinical-item-collection-table-view={true}
+    >
       <Table
         isPadded={true}
         isStriped={true}
@@ -593,67 +711,85 @@ exports[`test should render with one row 1`] = `
           Object {
             "tableLayout": "fixed",
           }
-        }>
+        }
+      >
         <TableHeader
           style={
             Object {
               "visibility": "hidden",
             }
-          }>
+          }
+        >
           <TableHeaderCell
-            columnType="accessory" />
+            columnType="accessory"
+          />
           <TableHeaderCell
-            columnType="display" />
+            columnType="display"
+          />
           <TableHeaderCell
-            columnType="display" />
+            columnType="display"
+          />
           <TableHeaderCell
-            columnType="comment" />
+            columnType="comment"
+          />
           <TableHeaderCell
-            columnType="accessory" />
+            columnType="accessory"
+          />
         </TableHeader>
         <SingleSelectableRows
-          onChange={[Function]}>
+          onChange={[Function]}
+        >
           <TableRow
             isSelectable={true}
-            isSelected={false}>
+            isSelected={false}
+          >
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   Start Accessory
                 </p>
-              } />
+              }
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 1" />
+                  text="Display 1"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemDisplay
                   isTruncated={false}
-                  text="Display 2" />
+                  text="Display 2"
+                />
               }
-              data-terra-clinical-item-collection-content="display" />
+              data-terra-clinical-item-collection-content="display"
+            />
             <TableCell
               content={
                 <ItemComment
                   isTruncated={false}
-                  text="test comment" />
+                  text="test comment"
+                />
               }
-              data-terra-clinical-item-collection-content="comment" />
+              data-terra-clinical-item-collection-content="comment"
+            />
             <TableCell
               className="content-accessory"
               content={
                 <p>
                   End Accessory
                 </p>
-              } />
+              }
+            />
           </TableRow>
         </SingleSelectableRows>
       </Table>
     </div>
-  } />
+  }
+/>
 `;

--- a/packages/terra-clinical-item-collection/tests/jest/__snapshots__/TableHeaderCell.test.jsx.snap
+++ b/packages/terra-clinical-item-collection/tests/jest/__snapshots__/TableHeaderCell.test.jsx.snap
@@ -1,16 +1,22 @@
-exports[`test should render accessory, comment and display table headers 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render accessory, comment and display table headers 1`] = `
 <thead
-  style="visibility:hidden;">
+  style="visibility:hidden;"
+>
   <tr>
     <th
       class="column-accessory"
-      id="accessory" />
+      id="accessory"
+    />
     <th
       data-terra-clinical-item-collection-column="comment"
-      id="comment" />
+      id="comment"
+    />
     <th
       data-terra-clinical-item-collection-column="display"
-      id="display" />
+      id="display"
+    />
   </tr>
 </thead>
 `;

--- a/packages/terra-clinical-item-display/package.json
+++ b/packages/terra-clinical-item-display/package.json
@@ -42,7 +42,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "$(cd ..; npm bin)/props-table ./src/ItemDisplay.jsx ./src/ItemComment.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-clinical-item-display/tests/jest/__snapshots__/ItemComment.test.jsx.snap
+++ b/packages/terra-clinical-item-display/tests/jest/__snapshots__/ItemComment.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`test should render a comment with text 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a comment with text 1`] = `
 <ItemDisplay
   className="item-comment"
   icon={
@@ -7,13 +9,15 @@ exports[`test should render a comment with text 1`] = `
       data-name="Layer 1"
       isBidi={true}
       viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
+      xmlns="http://www.w3.org/2000/svg"
+    />
   }
   isTruncated={false}
-  text="comment" />
+  text="comment"
+/>
 `;
 
-exports[`test should render a comment with the attention textStyle on text 1`] = `
+exports[`should render a comment with the attention textStyle on text 1`] = `
 <ItemDisplay
   className="item-comment"
   icon={
@@ -22,30 +26,16 @@ exports[`test should render a comment with the attention textStyle on text 1`] =
       data-name="Layer 1"
       isBidi={true}
       viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
-  }
-  isTruncated={false}
-  text="ItemComment"
-  textStyle="attention" />
-`;
-
-exports[`test should render a comment with the secondary textStyle on text 1`] = `
-<ItemDisplay
-  className="item-comment"
-  icon={
-    <IconComment
-      className=""
-      data-name="Layer 1"
-      isBidi={true}
-      viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
+      xmlns="http://www.w3.org/2000/svg"
+    />
   }
   isTruncated={false}
   text="ItemComment"
-  textStyle="secondary" />
+  textStyle="attention"
+/>
 `;
 
-exports[`test should render a comment with the strikeThrough textStyle on text 1`] = `
+exports[`should render a comment with the secondary textStyle on text 1`] = `
 <ItemDisplay
   className="item-comment"
   icon={
@@ -54,14 +44,16 @@ exports[`test should render a comment with the strikeThrough textStyle on text 1
       data-name="Layer 1"
       isBidi={true}
       viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
+      xmlns="http://www.w3.org/2000/svg"
+    />
   }
   isTruncated={false}
   text="ItemComment"
-  textStyle="strikeThrough" />
+  textStyle="secondary"
+/>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a comment with the strikeThrough textStyle on text 1`] = `
 <ItemDisplay
   className="item-comment"
   icon={
@@ -70,13 +62,16 @@ exports[`test should render a default component 1`] = `
       data-name="Layer 1"
       isBidi={true}
       viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
+      xmlns="http://www.w3.org/2000/svg"
+    />
   }
   isTruncated={false}
-  text="" />
+  text="ItemComment"
+  textStyle="strikeThrough"
+/>
 `;
 
-exports[`test should render a truncated comment 1`] = `
+exports[`should render a default component 1`] = `
 <ItemDisplay
   className="item-comment"
   icon={
@@ -85,8 +80,27 @@ exports[`test should render a truncated comment 1`] = `
       data-name="Layer 1"
       isBidi={true}
       viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg" />
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  }
+  isTruncated={false}
+  text=""
+/>
+`;
+
+exports[`should render a truncated comment 1`] = `
+<ItemDisplay
+  className="item-comment"
+  icon={
+    <IconComment
+      className=""
+      data-name="Layer 1"
+      isBidi={true}
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+    />
   }
   isTruncated={true}
-  text="comment1comment1comment1comment1comment1comment1comment1comment1" />
+  text="comment1comment1comment1comment1comment1comment1comment1comment1"
+/>
 `;

--- a/packages/terra-clinical-item-display/tests/jest/__snapshots__/ItemDisplay.test.jsx.snap
+++ b/packages/terra-clinical-item-display/tests/jest/__snapshots__/ItemDisplay.test.jsx.snap
@@ -1,84 +1,106 @@
-exports[`test should render a default component 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render a default component 1`] = `
 <div
-  className="item-display">
+  className="item-display"
+>
   <div
-    className="text" />
+    className="text"
+  />
 </div>
 `;
 
-exports[`test should render a display with the attention textStyle on text 1`] = `
+exports[`should render a display with the attention textStyle on text 1`] = `
 <div
-  className="item-display">
+  className="item-display"
+>
   <div
-    className="text attention">
+    className="text attention"
+  >
     Display
   </div>
 </div>
 `;
 
-exports[`test should render a display with the secondary textStyle on text 1`] = `
+exports[`should render a display with the secondary textStyle on text 1`] = `
 <div
-  className="item-display">
+  className="item-display"
+>
   <div
-    className="text secondary">
+    className="text secondary"
+  >
     Display
   </div>
 </div>
 `;
 
-exports[`test should render a display with the strikeThrough textStyle on text 1`] = `
+exports[`should render a display with the strikeThrough textStyle on text 1`] = `
 <div
-  className="item-display">
+  className="item-display"
+>
   <div
-    className="text strikeThrough">
+    className="text strikeThrough"
+  >
     Display
   </div>
 </div>
 `;
 
-exports[`test should render a truncated display 1`] = `
+exports[`should render a truncated display 1`] = `
 <div
-  className="item-display">
+  className="item-display"
+>
   <div
-    className="text is-truncated">
+    className="text is-truncated"
+  >
     display1display1display1display1display1display1display1display1
   </div>
 </div>
 `;
 
-exports[`test should render with a graphic 1`] = `
+exports[`should render with a graphic 1`] = `
 <div
-  className="item-display">
+  className="item-display"
+>
   <div
-    className="inline-icon">
+    className="inline-icon"
+  >
     <img
-      alt="Graphic" />
+      alt="Graphic"
+    />
   </div>
   <div
-    className="text" />
+    className="text"
+  />
 </div>
 `;
 
-exports[`test should render with text 1`] = `
+exports[`should render with text 1`] = `
 <div
-  className="item-display">
+  className="item-display"
+>
   <div
-    className="text">
+    className="text"
+  >
     Display
   </div>
 </div>
 `;
 
-exports[`test should render with text and graphic 1`] = `
+exports[`should render with text and graphic 1`] = `
 <div
-  className="item-display">
+  className="item-display"
+>
   <div
-    className="inline-icon">
+    className="inline-icon"
+  >
     <img
-      alt="Graphic" />
+      alt="Graphic"
+    />
   </div>
   <div
-    className="text">
+    className="text"
+  >
     Display
   </div>
 </div>

--- a/packages/terra-clinical-item-view/package.json
+++ b/packages/terra-clinical-item-view/package.json
@@ -44,7 +44,7 @@
     "props-table": "$(cd ..; npm bin)/props-table ./src/ItemView.jsx --out-dir ./docs/props-table",
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-clinical-item-view/tests/jest/__snapshots__/ItemView.test.jsx.snap
+++ b/packages/terra-clinical-item-view/tests/jest/__snapshots__/ItemView.test.jsx.snap
@@ -1,17 +1,25 @@
-exports[`test should render 1 start theme display 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render 1 start theme display 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body">
+    className="body"
+  >
     <div
-      className="row-container">
+      className="row-container"
+    >
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 1" />
+            text="display 1"
+          />
         </div>
       </div>
     </div>
@@ -19,29 +27,38 @@ exports[`test should render 1 start theme display 1`] = `
 </div>
 `;
 
-exports[`test should render 2 start theme displays 1`] = `
+exports[`should render 2 start theme displays 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body">
+    className="body"
+  >
     <div
-      className="row-container">
+      className="row-container"
+    >
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 1" />
+            text="display 1"
+          />
         </div>
       </div>
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-secondarySize content-secondaryColor">
+          className="content content-secondarySize content-secondaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 2" />
+            text="display 2"
+          />
         </div>
       </div>
     </div>
@@ -49,38 +66,50 @@ exports[`test should render 2 start theme displays 1`] = `
 </div>
 `;
 
-exports[`test should render 3 start theme displays 1`] = `
+exports[`should render 3 start theme displays 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body">
+    className="body"
+  >
     <div
-      className="row-container">
+      className="row-container"
+    >
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 1" />
+            text="display 1"
+          />
         </div>
       </div>
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-secondarySize content-primaryColor">
+          className="content content-secondarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 2" />
+            text="display 2"
+          />
         </div>
       </div>
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-secondarySize content-secondaryColor">
+          className="content content-secondarySize content-secondaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 3" />
+            text="display 3"
+          />
         </div>
       </div>
     </div>
@@ -88,102 +117,132 @@ exports[`test should render 3 start theme displays 1`] = `
 </div>
 `;
 
-exports[`test should render a comment 1`] = `
+exports[`should render a comment 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body">
+    className="body"
+  >
     <ItemComment
       isTruncated={false}
       text="comment"
-      textStyle="attention" />
+      textStyle="attention"
+    />
   </div>
 </div>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a default component 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body" />
+    className="body"
+  />
 </div>
 `;
 
-exports[`test should render a end accessory 1`] = `
+exports[`should render a end accessory 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body" />
+    className="body"
+  />
   <div
-    className="accessory accessory-alignCenter">
+    className="accessory accessory-alignCenter"
+  >
     <img
-      alt="Graphic" />
+      alt="Graphic"
+    />
   </div>
 </div>
 `;
 
-exports[`test should render a start accessory 1`] = `
+exports[`should render a start accessory 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="accessory accessory-alignCenter">
+    className="accessory accessory-alignCenter"
+  >
     <img
-      alt="Graphic" />
+      alt="Graphic"
+    />
   </div>
   <div
-    className="body" />
+    className="body"
+  />
 </div>
 `;
 
-exports[`test should render an accessory center aligned 1`] = `
+exports[`should render an accessory center aligned 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="accessory accessory-alignCenter">
+    className="accessory accessory-alignCenter"
+  >
     <img
-      alt="Graphic" />
+      alt="Graphic"
+    />
   </div>
   <div
-    className="body" />
+    className="body"
+  />
 </div>
 `;
 
-exports[`test should render an accessory top aligned 1`] = `
+exports[`should render an accessory top aligned 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="accessory accessory-alignTop">
+    className="accessory accessory-alignTop"
+  >
     <img
-      alt="Graphic" />
+      alt="Graphic"
+    />
   </div>
   <div
-    className="body" />
+    className="body"
+  />
 </div>
 `;
 
-exports[`test should render one column 1`] = `
+exports[`should render one column 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body">
+    className="body"
+  >
     <div
-      className="row-container">
+      className="row-container"
+    >
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 1" />
+            text="display 1"
+          />
         </div>
       </div>
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-secondarySize content-secondaryColor">
+          className="content content-secondarySize content-secondaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 2" />
+            text="display 2"
+          />
         </div>
       </div>
     </div>
@@ -191,20 +250,26 @@ exports[`test should render one column 1`] = `
 </div>
 `;
 
-exports[`test should render truncated display 1`] = `
+exports[`should render truncated display 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body">
+    className="body"
+  >
     <div
-      className="row-container">
+      className="row-container"
+    >
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={true}
-            text="display1display1display1display1display1display1display1display1" />
+            text="display1display1display1display1display1display1display1display1"
+          />
         </div>
       </div>
     </div>
@@ -212,71 +277,94 @@ exports[`test should render truncated display 1`] = `
 </div>
 `;
 
-exports[`test should render two columns with 8 displays 1`] = `
+exports[`should render two columns with 8 displays 1`] = `
 <div
-  className="item-view twoColumns">
+  className="item-view twoColumns"
+>
   <div
-    className="body">
+    className="body"
+  >
     <div
-      className="row-container">
+      className="row-container"
+    >
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 1" />
+            text="display 1"
+          />
         </div>
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 2" />
+            text="display 2"
+          />
         </div>
       </div>
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-secondarySize content-primaryColor">
+          className="content content-secondarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 3" />
+            text="display 3"
+          />
         </div>
         <div
-          className="content content-secondarySize content-primaryColor">
+          className="content content-secondarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 4" />
-        </div>
-      </div>
-      <div
-        className="row">
-        <div
-          className="content content-secondarySize content-secondaryColor">
-          <ItemDisplay
-            isTruncated={false}
-            text="display 5" />
-        </div>
-        <div
-          className="content content-secondarySize content-secondaryColor">
-          <ItemDisplay
-            isTruncated={false}
-            text="display 6" />
+            text="display 4"
+          />
         </div>
       </div>
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-secondarySize content-secondaryColor">
+          className="content content-secondarySize content-secondaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 7" />
+            text="display 5"
+          />
         </div>
         <div
-          className="content content-secondarySize content-secondaryColor">
+          className="content content-secondarySize content-secondaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 8" />
+            text="display 6"
+          />
+        </div>
+      </div>
+      <div
+        className="row"
+      >
+        <div
+          className="content content-secondarySize content-secondaryColor"
+        >
+          <ItemDisplay
+            isTruncated={false}
+            text="display 7"
+          />
+        </div>
+        <div
+          className="content content-secondarySize content-secondaryColor"
+        >
+          <ItemDisplay
+            isTruncated={false}
+            text="display 8"
+          />
         </div>
       </div>
     </div>
@@ -284,35 +372,46 @@ exports[`test should render two columns with 8 displays 1`] = `
 </div>
 `;
 
-exports[`test should render two columns with odd number of displays 1`] = `
+exports[`should render two columns with odd number of displays 1`] = `
 <div
-  className="item-view twoColumns">
+  className="item-view twoColumns"
+>
   <div
-    className="body">
+    className="body"
+  >
     <div
-      className="row-container">
+      className="row-container"
+    >
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 1" />
+            text="display 1"
+          />
         </div>
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 2" />
+            text="display 2"
+          />
         </div>
       </div>
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-secondarySize content-secondaryColor">
+          className="content content-secondarySize content-secondaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 3" />
+            text="display 3"
+          />
         </div>
       </div>
     </div>
@@ -320,20 +419,26 @@ exports[`test should render two columns with odd number of displays 1`] = `
 </div>
 `;
 
-exports[`test should render with 1 display 1`] = `
+exports[`should render with 1 display 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body">
+    className="body"
+  >
     <div
-      className="row-container">
+      className="row-container"
+    >
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 1" />
+            text="display 1"
+          />
         </div>
       </div>
     </div>
@@ -341,29 +446,38 @@ exports[`test should render with 1 display 1`] = `
 </div>
 `;
 
-exports[`test should render with 2 displays 1`] = `
+exports[`should render with 2 displays 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body">
+    className="body"
+  >
     <div
-      className="row-container">
+      className="row-container"
+    >
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 1" />
+            text="display 1"
+          />
         </div>
       </div>
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-secondarySize content-secondaryColor">
+          className="content content-secondarySize content-secondaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 2" />
+            text="display 2"
+          />
         </div>
       </div>
     </div>
@@ -371,38 +485,50 @@ exports[`test should render with 2 displays 1`] = `
 </div>
 `;
 
-exports[`test should render with 3 displays 1`] = `
+exports[`should render with 3 displays 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body">
+    className="body"
+  >
     <div
-      className="row-container">
+      className="row-container"
+    >
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 1" />
+            text="display 1"
+          />
         </div>
       </div>
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-secondarySize content-primaryColor">
+          className="content content-secondarySize content-primaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 2" />
+            text="display 2"
+          />
         </div>
       </div>
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-secondarySize content-secondaryColor">
+          className="content content-secondarySize content-secondaryColor"
+        >
           <ItemDisplay
             isTruncated={false}
-            text="display 3" />
+            text="display 3"
+          />
         </div>
       </div>
     </div>
@@ -410,24 +536,31 @@ exports[`test should render with 3 displays 1`] = `
 </div>
 `;
 
-exports[`test should render with a display and graphic 1`] = `
+exports[`should render with a display and graphic 1`] = `
 <div
-  className="item-view oneColumn">
+  className="item-view oneColumn"
+>
   <div
-    className="body">
+    className="body"
+  >
     <div
-      className="row-container">
+      className="row-container"
+    >
       <div
-        className="row">
+        className="row"
+      >
         <div
-          className="content content-primarySize content-primaryColor">
+          className="content content-primarySize content-primaryColor"
+        >
           <ItemDisplay
             icon={
               <img
-                alt="Graphic" />
+                alt="Graphic"
+              />
             }
             isTruncated={false}
-            text="display 1" />
+            text="display 1"
+          />
         </div>
       </div>
     </div>

--- a/packages/terra-clinical-label-value-view/package.json
+++ b/packages/terra-clinical-label-value-view/package.json
@@ -40,7 +40,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "$(cd ..; npm bin)/props-table ./src/LabelValueView.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-clinical-label-value-view/tests/jest/__snapshots__/LabelValueView.test.jsx.snap
+++ b/packages/terra-clinical-label-value-view/tests/jest/__snapshots__/LabelValueView.test.jsx.snap
@@ -1,8 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`LabelValueView should render LabelValueView for an node input 1`] = `
 <div
-  className="label-value-view">
+  className="label-value-view"
+>
   <div
-    className="label">
+    className="label"
+  >
     Label
   </div>
   <div>
@@ -13,13 +17,16 @@ exports[`LabelValueView should render LabelValueView for an node input 1`] = `
 
 exports[`LabelValueView should render LabelValueView for text and node inputs 1`] = `
 <div
-  className="label-value-view">
+  className="label-value-view"
+>
   <div
-    className="label">
+    className="label"
+  >
     Label
   </div>
   <div
-    className="value">
+    className="value"
+  >
     Sample Text 1
   </div>
   <div>
@@ -30,13 +37,16 @@ exports[`LabelValueView should render LabelValueView for text and node inputs 1`
 
 exports[`LabelValueView should render a LabelValueView for text input 1`] = `
 <div
-  className="label-value-view">
+  className="label-value-view"
+>
   <div
-    className="label">
+    className="label"
+  >
     Label
   </div>
   <div
-    className="value">
+    className="value"
+  >
     Sample Text
   </div>
 </div>
@@ -44,13 +54,16 @@ exports[`LabelValueView should render a LabelValueView for text input 1`] = `
 
 exports[`LabelValueView should render a default LabelValueView 1`] = `
 <div
-  className="label-value-view">
+  className="label-value-view"
+>
   <div
-    className="label">
+    className="label"
+  >
     Label
   </div>
   <div
-    className="value">
+    className="value"
+  >
     --
   </div>
 </div>

--- a/packages/terra-clinical-no-data-view/package.json
+++ b/packages/terra-clinical-no-data-view/package.json
@@ -42,7 +42,7 @@
     "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
     "props-table": "$(cd ..; npm bin)/props-table ./src/NoDataView.jsx --out-dir ./docs/props-table",
     "test": "npm run test:jest && npm run test:nightwatch",
-    "test:jest": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:jest": "$(cd ..; npm bin)/jest ./tests/jest/* --config ../../jestconfig.json",
     "test:nightwatch": "$(cd ..; npm bin)/nightwatch -c ../../nightwatch.conf.js"
   }
 }

--- a/packages/terra-clinical-no-data-view/tests/jest/__snapshots__/NoDataView.test.jsx.snap
+++ b/packages/terra-clinical-no-data-view/tests/jest/__snapshots__/NoDataView.test.jsx.snap
@@ -1,123 +1,153 @@
-exports[`test should not render a glyph 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should not render a glyph 1`] = `
 <div
-  class="no-data-view" />
+  class="no-data-view"
+/>
 `;
 
-exports[`test should render a default component 1`] = `
+exports[`should render a default component 1`] = `
 <div
-  class="no-data-view">
+  class="no-data-view"
+>
   <div
-    class="glyph">
+    class="glyph"
+  >
     <svg
       data-name="Layer 1"
       id="Layer_1"
       style="height:170px;width:170px;"
-      viewbox="0 0 251.73 251.73">
+      viewbox="0 0 251.73 251.73"
+    >
       <path
         d="M127.72,9.76a118,118,0,0,1,45.9,226.59A118,118,0,0,1,81.82,19a117.18,117.18,0,0,1,45.9-9.26m0-7.94A125.87,125.87,0,1,0,253.58,127.69,125.87,125.87,0,0,0,127.72,1.83Z"
         style="fill:#f4f4f4;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
       <path
         d="M94.29,116.54a5.13,5.13,0,0,1,4.56-2.77h83.78V103.2a5.25,5.25,0,0,0-5.2-5.2l-46.33.24a13.44,13.44,0,0,1-8.75-3.78l-9-9.22a13.44,13.44,0,0,0-8.75-3.78H74.37a5.25,5.25,0,0,0-5.2,5.2v79.42c0,.08,0,.15,0,.23a4.94,4.94,0,0,1,.55-2.08Z"
         style="fill:#e8e9ea;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
       <path
         d="M201.85,113.77h-103a5.13,5.13,0,0,0-4.56,2.77L69.73,164.22a4.94,4.94,0,0,0-.55,2.08,5,5,0,0,0,5,5.21H177.35a5.13,5.13,0,0,0,4.56-2.77l24.5-47.59A5.08,5.08,0,0,0,201.85,113.77Z"
         style="fill:#f4f4f4;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
     </svg>
   </div>
 </div>
 `;
 
-exports[`test should render a heading 1`] = `
+exports[`should render a heading 1`] = `
 <div
-  class="no-data-view">
+  class="no-data-view"
+>
   <div
-    class="glyph">
+    class="glyph"
+  >
     <svg
       data-name="Layer 1"
       id="Layer_1"
       style="height:170px;width:170px;"
-      viewbox="0 0 251.73 251.73">
+      viewbox="0 0 251.73 251.73"
+    >
       <path
         d="M127.72,9.76a118,118,0,0,1,45.9,226.59A118,118,0,0,1,81.82,19a117.18,117.18,0,0,1,45.9-9.26m0-7.94A125.87,125.87,0,1,0,253.58,127.69,125.87,125.87,0,0,0,127.72,1.83Z"
         style="fill:#f4f4f4;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
       <path
         d="M94.29,116.54a5.13,5.13,0,0,1,4.56-2.77h83.78V103.2a5.25,5.25,0,0,0-5.2-5.2l-46.33.24a13.44,13.44,0,0,1-8.75-3.78l-9-9.22a13.44,13.44,0,0,0-8.75-3.78H74.37a5.25,5.25,0,0,0-5.2,5.2v79.42c0,.08,0,.15,0,.23a4.94,4.94,0,0,1,.55-2.08Z"
         style="fill:#e8e9ea;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
       <path
         d="M201.85,113.77h-103a5.13,5.13,0,0,0-4.56,2.77L69.73,164.22a4.94,4.94,0,0,0-.55,2.08,5,5,0,0,0,5,5.21H177.35a5.13,5.13,0,0,0,4.56-2.77l24.5-47.59A5.08,5.08,0,0,0,201.85,113.77Z"
         style="fill:#f4f4f4;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
     </svg>
   </div>
   <p
-    class="heading">
+    class="heading"
+  >
     test heading
   </p>
 </div>
 `;
 
-exports[`test should render a subtext 1`] = `
+exports[`should render a subtext 1`] = `
 <div
-  class="no-data-view">
+  class="no-data-view"
+>
   <div
-    class="glyph">
+    class="glyph"
+  >
     <svg
       data-name="Layer 1"
       id="Layer_1"
       style="height:170px;width:170px;"
-      viewbox="0 0 251.73 251.73">
+      viewbox="0 0 251.73 251.73"
+    >
       <path
         d="M127.72,9.76a118,118,0,0,1,45.9,226.59A118,118,0,0,1,81.82,19a117.18,117.18,0,0,1,45.9-9.26m0-7.94A125.87,125.87,0,1,0,253.58,127.69,125.87,125.87,0,0,0,127.72,1.83Z"
         style="fill:#f4f4f4;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
       <path
         d="M94.29,116.54a5.13,5.13,0,0,1,4.56-2.77h83.78V103.2a5.25,5.25,0,0,0-5.2-5.2l-46.33.24a13.44,13.44,0,0,1-8.75-3.78l-9-9.22a13.44,13.44,0,0,0-8.75-3.78H74.37a5.25,5.25,0,0,0-5.2,5.2v79.42c0,.08,0,.15,0,.23a4.94,4.94,0,0,1,.55-2.08Z"
         style="fill:#e8e9ea;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
       <path
         d="M201.85,113.77h-103a5.13,5.13,0,0,0-4.56,2.77L69.73,164.22a4.94,4.94,0,0,0-.55,2.08,5,5,0,0,0,5,5.21H177.35a5.13,5.13,0,0,0,4.56-2.77l24.5-47.59A5.08,5.08,0,0,0,201.85,113.77Z"
         style="fill:#f4f4f4;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
     </svg>
   </div>
   <p
-    class="subtext">
+    class="subtext"
+  >
     test subtext.
   </p>
 </div>
 `;
 
-exports[`test should render a with subtext content 1`] = `
+exports[`should render a with subtext content 1`] = `
 <div
-  class="no-data-view">
+  class="no-data-view"
+>
   <div
-    class="glyph">
+    class="glyph"
+  >
     <svg
       data-name="Layer 1"
       id="Layer_1"
       style="height:170px;width:170px;"
-      viewbox="0 0 251.73 251.73">
+      viewbox="0 0 251.73 251.73"
+    >
       <path
         d="M127.72,9.76a118,118,0,0,1,45.9,226.59A118,118,0,0,1,81.82,19a117.18,117.18,0,0,1,45.9-9.26m0-7.94A125.87,125.87,0,1,0,253.58,127.69,125.87,125.87,0,0,0,127.72,1.83Z"
         style="fill:#f4f4f4;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
       <path
         d="M94.29,116.54a5.13,5.13,0,0,1,4.56-2.77h83.78V103.2a5.25,5.25,0,0,0-5.2-5.2l-46.33.24a13.44,13.44,0,0,1-8.75-3.78l-9-9.22a13.44,13.44,0,0,0-8.75-3.78H74.37a5.25,5.25,0,0,0-5.2,5.2v79.42c0,.08,0,.15,0,.23a4.94,4.94,0,0,1,.55-2.08Z"
         style="fill:#e8e9ea;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
       <path
         d="M201.85,113.77h-103a5.13,5.13,0,0,0-4.56,2.77L69.73,164.22a4.94,4.94,0,0,0-.55,2.08,5,5,0,0,0,5,5.21H177.35a5.13,5.13,0,0,0,4.56-2.77l24.5-47.59A5.08,5.08,0,0,0,201.85,113.77Z"
         style="fill:#f4f4f4;"
-        transform="translate(-1.85 -1.83)" />
+        transform="translate(-1.85 -1.83)"
+      />
     </svg>
   </div>
   <div
-    class="subtext-content">
+    class="subtext-content"
+  >
     <p>
       test subtextContent
     </p>


### PR DESCRIPTION
### Summary
Sync with terra-clinal PR #798 which references issue #323 to update Jest dependency.

With Jest v21, compared to Jest v18, snapshots have some changes in how they are rendering.

Closing angle brackets are rendered on their own line.

```diff
<div>
-  className="test">
+   className="test"
+ >
```

```diff
- }>
+  }
+ >
```

The word `test` is no longer included in export in snapshot

```diff
- exports[`test should render ...`] = `
+ exports[`should render ...`] = `
```

Snapshots include version number in snapshot

```diff
+ // Jest Snapshot v1, https://goo.gl/fbAQLP
```

DOM elements / React Components which were empty now render differently

```diff
- <div />
+ <div>
+ 
+ </div>
```

This is the majority of the diffs in this PR.
