### PR TITLE
Set webpack dev server at 2.7.1 for IE10 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,6 @@
     "terra-props-table": "^1.0.0",
     "terra-toolkit": "^2.1.0",
     "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.9.1"
+    "webpack-dev-server": "^2.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -96,6 +96,6 @@
     "terra-props-table": "^1.0.0",
     "terra-toolkit": "^2.1.0",
     "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.7.1"
+    "webpack-dev-server": "2.7.1"
   }
 }

--- a/packages/terra-clinical-site/CHANGELOG.md
+++ b/packages/terra-clinical-site/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Changed
-Lock wepback-dev-server at last version supporting IE10 (1.7.1)
+Lock webpack-dev-server at last version supporting IE10 (1.7.1)
 
 1.3.0 - (August 16, 2017)
 -----------------

--- a/packages/terra-clinical-site/CHANGELOG.md
+++ b/packages/terra-clinical-site/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+Lock wepback-dev-server at last version supporting IE10 (1.7.1)
 
 1.3.0 - (August 16, 2017)
 -----------------

--- a/packages/terra-clinical-site/package.json
+++ b/packages/terra-clinical-site/package.json
@@ -84,6 +84,6 @@
     "style-loader": "^0.19.0",
     "terra-i18n-plugin": "^1.5.0",
     "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.7.1"
+    "webpack-dev-server": "2.7.1"
   }
 }

--- a/packages/terra-clinical-site/package.json
+++ b/packages/terra-clinical-site/package.json
@@ -84,6 +84,6 @@
     "style-loader": "^0.19.0",
     "terra-i18n-plugin": "^1.5.0",
     "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.9.1"
+    "webpack-dev-server": "^2.7.1"
   }
 }


### PR DESCRIPTION
### Summary
Webpack > 2.7.1 dropped IE 10 & 11 support.
See https://github.com/cerner/terra-core/pull/901
Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
