### PR TITLE
Update Site Header to use Collapsible Menu View 

### DIFF
--- a/packages/terra-clinical-site/CHANGELOG.md
+++ b/packages/terra-clinical-site/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Uplift site header to use collapsible menu view
 
 1.3.0 - (August 16, 2017)
 -----------------

--- a/packages/terra-clinical-site/package.json
+++ b/packages/terra-clinical-site/package.json
@@ -43,6 +43,7 @@
     "terra-clinical-item-view": "^1.4.0",
     "terra-clinical-label-value-view": "^1.3.0",
     "terra-clinical-no-data-view": "^1.3.0",
+    "terra-collapsible-menu-view": "^1.0.0",
     "terra-content-container": "^1.0.0",
     "terra-i18n": "^1.0.0",
     "terra-icon": "^1.0.0",

--- a/packages/terra-clinical-site/src/App.jsx
+++ b/packages/terra-clinical-site/src/App.jsx
@@ -119,6 +119,7 @@ class App extends React.Component {
       <CollapsibleMenuView className={styles.header}>
         {toggleContent}
         {localeContent}
+        <CollapsibleMenuView.Divider />
         {bidiContent}
       </CollapsibleMenuView>
     );

--- a/packages/terra-clinical-site/src/App.jsx
+++ b/packages/terra-clinical-site/src/App.jsx
@@ -3,8 +3,7 @@ import Base from 'terra-base';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
-import Button from 'terra-button';
-import ButtonGroup from 'terra-button-group';
+import CollapsibleMenuView from 'terra-collapsible-menu-view';
 import ContentContainer from 'terra-content-container';
 import IconMenu from 'terra-icon/lib/icon/IconMenu';
 import List from 'terra-list';
@@ -22,15 +21,22 @@ class App extends React.Component {
     super(props);
     this.state = {
       isOpen: window.innerWidth >= 768,
+      isLtr: true,
       locale,
     };
+    this.handleBidiChange = this.handleBidiChange.bind(this);
     this.handleLocaleChange = this.handleLocaleChange.bind(this);
     this.handleToggleClick = this.handleToggleClick.bind(this);
     this.handleResetScroll = this.handleResetScroll.bind(this);
   }
 
+  handleBidiChange(e) {
+    document.getElementsByTagName('html')[0].setAttribute('dir', e.currentTarget.id);
+    this.setState({ isLtr: e.currentTarget.id === 'ltr' });
+  }
+
   handleLocaleChange(e) {
-    this.setState({ locale: e.target.value });
+    this.setState({ locale: e.currentTarget.id });
   }
 
   handleToggleClick() {
@@ -49,36 +55,33 @@ class App extends React.Component {
 
   render() {
     const toggleContent = (
-      <Button icon={<IconMenu />} onClick={this.handleToggleClick} />
+      <CollapsibleMenuView.Item icon={<IconMenu />} isIconOnly key="toggle-content" onClick={this.handleToggleClick} />
     );
 
     const bidiContent = (
-      <ButtonGroup
-        className={styles.bidirectionality}
-        dir="ltr"
-        size="medium"
-        isSelectable
-        buttons={[
-          <ButtonGroup.Button isSelected text="ltr" key="ltr" onClick={() => document.getElementsByTagName('html')[0].setAttribute('dir', 'ltr')} />,
-          <ButtonGroup.Button text="rtl" key="rtl" onClick={() => document.getElementsByTagName('html')[0].setAttribute('dir', 'rtl')} />,
-        ]}
-      />
+      <CollapsibleMenuView.ItemGroup key="site-bidi" isSelectable dir="ltr" size="medium">
+        <CollapsibleMenuView.Item id="ltr" text="ltr" key="ltr" isSelected={this.state.isLtr} onClick={this.handleBidiChange} />
+        <CollapsibleMenuView.Item id="rtl" text="rtl" key="rtl" isSelected={!this.state.isLtr} onClick={this.handleBidiChange} />
+      </CollapsibleMenuView.ItemGroup>
    );
 
     const localeContent = (
-      <div className={styles.locale}>
-        <label htmlFor="locale">Locale:</label>
-        <select value={this.state.locale} onChange={this.handleLocaleChange}>
-          <option value="en">en</option>
-          <option value="en-GB">en-GB</option>
-          <option value="en-US">en-US</option>
-          <option value="de">de</option>
-          <option value="es">es</option>
-          <option value="fr">fr</option>
-          <option value="pt">pt</option>
-          <option value="fi-FI">fi-FI</option>
-        </select>
-      </div>
+      <CollapsibleMenuView.Item
+        text={`Locale: ${this.state.locale}`}
+        key="locale"
+        menuWidth="160"
+        shouldCloseOnClick={false}
+        subMenuItems={[
+          <CollapsibleMenuView.Item id="en" text="en" key="en" onClick={this.handleLocaleChange} />,
+          <CollapsibleMenuView.Item id="en-GB" text="en-GB" key="en-GB" onClick={this.handleLocaleChange} />,
+          <CollapsibleMenuView.Item id="en-US" text="en-US" key="en-US" onClick={this.handleLocaleChange} />,
+          <CollapsibleMenuView.Item id="de" text="de" key="de" onClick={this.handleLocaleChange} />,
+          <CollapsibleMenuView.Item id="es" text="es" key="es" onClick={this.handleLocaleChange} />,
+          <CollapsibleMenuView.Item id="fr" text="fr" key="fr" onClick={this.handleLocaleChange} />,
+          <CollapsibleMenuView.Item id="pt" text="pt" key="pt"onClick={this.handleLocaleChange} />,
+          <CollapsibleMenuView.Item id="fi-FI" text="fi-FI" key="fi-FI" onClick={this.handleLocaleChange} />,
+        ]}
+      />
    );
 
     const navHeader = (
@@ -112,18 +115,12 @@ class App extends React.Component {
       </Base>
     );
 
-    const utilityContent = (
-      <div className={styles.utility}>
+    const applicationHeader = (
+      <CollapsibleMenuView className={styles.header}>
+        {toggleContent}
         {localeContent}
         {bidiContent}
-      </div>
-    );
-
-    const applicationHeader = (
-      <div className={styles.header}>
-        {toggleContent}
-        {utilityContent}
-      </div>
+      </CollapsibleMenuView>
     );
 
     return (

--- a/packages/terra-clinical-site/src/App.jsx
+++ b/packages/terra-clinical-site/src/App.jsx
@@ -59,9 +59,9 @@ class App extends React.Component {
     );
 
     const bidiContent = (
-      <CollapsibleMenuView.ItemGroup key="site-bidi" isSelectable dir="ltr" size="medium">
-        <CollapsibleMenuView.Item id="ltr" text="ltr" key="ltr" isSelected={this.state.dir === 'ltr'} onClick={this.handleBidiChange} />
-        <CollapsibleMenuView.Item id="rtl" text="rtl" key="rtl" isSelected={this.state.dir === 'rtl'} onClick={this.handleBidiChange} />
+      <CollapsibleMenuView.ItemGroup key="site-bidi" isSelectable dir="ltr" size="medium" onChange={this.handleBidiChange}>
+        <CollapsibleMenuView.Item id="ltr" text="ltr" key="ltr" isSelected={this.state.dir === 'ltr'} />
+        <CollapsibleMenuView.Item id="rtl" text="rtl" key="rtl" isSelected={this.state.dir === 'rtl'} />
       </CollapsibleMenuView.ItemGroup>
    );
 
@@ -72,15 +72,15 @@ class App extends React.Component {
         menuWidth="160"
         shouldCloseOnClick={false}
         subMenuItems={[
-          <CollapsibleMenuView.ItemGroup isSelectable key="local-options">
-            <CollapsibleMenuView.Item id="en" text="en" key="en" isSelected={this.state.locale === 'en'} onClick={this.handleLocaleChange} />
-            <CollapsibleMenuView.Item id="en-GB" text="en-GB" key="en-GB" isSelected={this.state.locale === 'en-GB'} onClick={this.handleLocaleChange} />
-            <CollapsibleMenuView.Item id="en-US" text="en-US" key="en-US" isSelected={this.state.locale === 'en-US'} onClick={this.handleLocaleChange} />
-            <CollapsibleMenuView.Item id="de" text="de" key="de" isSelected={this.state.locale === 'de'} onClick={this.handleLocaleChange} />
-            <CollapsibleMenuView.Item id="es" text="es" key="es" isSelected={this.state.locale === 'es'} onClick={this.handleLocaleChange} />
-            <CollapsibleMenuView.Item id="fr" text="fr" key="fr" isSelected={this.state.locale === 'fr'} onClick={this.handleLocaleChange} />
-            <CollapsibleMenuView.Item id="pt" text="pt" key="pt" isSelected={this.state.locale === 'pt'} onClick={this.handleLocaleChange} />
-            <CollapsibleMenuView.Item id="fi-FI" text="fi-FI" key="fi-FI" isSelected={this.state.locale === 'fi-FI'} onClick={this.handleLocaleChange} />
+          <CollapsibleMenuView.ItemGroup isSelectable key="local-options" onChange={this.handleLocaleChange}>
+            <CollapsibleMenuView.Item id="en" text="en" key="en" isSelected={this.state.locale === 'en'} />
+            <CollapsibleMenuView.Item id="en-GB" text="en-GB" key="en-GB" isSelected={this.state.locale === 'en-GB'} />
+            <CollapsibleMenuView.Item id="en-US" text="en-US" key="en-US" isSelected={this.state.locale === 'en-US'} />
+            <CollapsibleMenuView.Item id="de" text="de" key="de" isSelected={this.state.locale === 'de'} />
+            <CollapsibleMenuView.Item id="es" text="es" key="es" isSelected={this.state.locale === 'es'} />
+            <CollapsibleMenuView.Item id="fr" text="fr" key="fr" isSelected={this.state.locale === 'fr'} />
+            <CollapsibleMenuView.Item id="pt" text="pt" key="pt" isSelected={this.state.locale === 'pt'} />
+            <CollapsibleMenuView.Item id="fi-FI" text="fi-FI" key="fi-FI" isSelected={this.state.locale === 'fi-FI'} />
           </CollapsibleMenuView.ItemGroup>,
         ]}
       />

--- a/packages/terra-clinical-site/src/App.jsx
+++ b/packages/terra-clinical-site/src/App.jsx
@@ -72,14 +72,16 @@ class App extends React.Component {
         menuWidth="160"
         shouldCloseOnClick={false}
         subMenuItems={[
-          <CollapsibleMenuView.Item id="en" text="en" key="en" onClick={this.handleLocaleChange} />,
-          <CollapsibleMenuView.Item id="en-GB" text="en-GB" key="en-GB" onClick={this.handleLocaleChange} />,
-          <CollapsibleMenuView.Item id="en-US" text="en-US" key="en-US" onClick={this.handleLocaleChange} />,
-          <CollapsibleMenuView.Item id="de" text="de" key="de" onClick={this.handleLocaleChange} />,
-          <CollapsibleMenuView.Item id="es" text="es" key="es" onClick={this.handleLocaleChange} />,
-          <CollapsibleMenuView.Item id="fr" text="fr" key="fr" onClick={this.handleLocaleChange} />,
-          <CollapsibleMenuView.Item id="pt" text="pt" key="pt"onClick={this.handleLocaleChange} />,
-          <CollapsibleMenuView.Item id="fi-FI" text="fi-FI" key="fi-FI" onClick={this.handleLocaleChange} />,
+          <CollapsibleMenuView.ItemGroup isSelectable key="local-options">
+            <CollapsibleMenuView.Item id="en" text="en" key="en" isSelected={this.state.locale === 'en'} onClick={this.handleLocaleChange} />
+            <CollapsibleMenuView.Item id="en-GB" text="en-GB" key="en-GB" isSelected={this.state.locale === 'en-GB'} onClick={this.handleLocaleChange} />
+            <CollapsibleMenuView.Item id="en-US" text="en-US" key="en-US" isSelected={this.state.locale === 'en-US'} onClick={this.handleLocaleChange} />
+            <CollapsibleMenuView.Item id="de" text="de" key="de" isSelected={this.state.locale === 'de'} onClick={this.handleLocaleChange} />
+            <CollapsibleMenuView.Item id="es" text="es" key="es" isSelected={this.state.locale === 'es'} onClick={this.handleLocaleChange} />
+            <CollapsibleMenuView.Item id="fr" text="fr" key="fr" isSelected={this.state.locale === 'fr'} onClick={this.handleLocaleChange} />
+            <CollapsibleMenuView.Item id="pt" text="pt" key="pt" isSelected={this.state.locale === 'pt'} onClick={this.handleLocaleChange} />
+            <CollapsibleMenuView.Item id="fi-FI" text="fi-FI" key="fi-FI" isSelected={this.state.locale === 'fi-FI'} onClick={this.handleLocaleChange} />
+          </CollapsibleMenuView.ItemGroup>,
         ]}
       />
    );

--- a/packages/terra-clinical-site/src/App.jsx
+++ b/packages/terra-clinical-site/src/App.jsx
@@ -21,7 +21,7 @@ class App extends React.Component {
     super(props);
     this.state = {
       isOpen: window.innerWidth >= 768,
-      isLtr: true,
+      dir: 'ltr',
       locale,
     };
     this.handleBidiChange = this.handleBidiChange.bind(this);
@@ -32,7 +32,7 @@ class App extends React.Component {
 
   handleBidiChange(e) {
     document.getElementsByTagName('html')[0].setAttribute('dir', e.currentTarget.id);
-    this.setState({ isLtr: e.currentTarget.id === 'ltr' });
+    this.setState({ dir: e.currentTarget.id });
   }
 
   handleLocaleChange(e) {
@@ -60,8 +60,8 @@ class App extends React.Component {
 
     const bidiContent = (
       <CollapsibleMenuView.ItemGroup key="site-bidi" isSelectable dir="ltr" size="medium">
-        <CollapsibleMenuView.Item id="ltr" text="ltr" key="ltr" isSelected={this.state.isLtr} onClick={this.handleBidiChange} />
-        <CollapsibleMenuView.Item id="rtl" text="rtl" key="rtl" isSelected={!this.state.isLtr} onClick={this.handleBidiChange} />
+        <CollapsibleMenuView.Item id="ltr" text="ltr" key="ltr" isSelected={this.state.dir === 'ltr'} onClick={this.handleBidiChange} />
+        <CollapsibleMenuView.Item id="rtl" text="rtl" key="rtl" isSelected={this.state.dir === 'rtl'} onClick={this.handleBidiChange} />
       </CollapsibleMenuView.ItemGroup>
    );
 

--- a/packages/terra-clinical-site/src/site.scss
+++ b/packages/terra-clinical-site/src/site.scss
@@ -39,39 +39,22 @@
     background-color: #80c7ee;
     border-bottom: 3px solid #047cc0;
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     overflow: hidden;
     padding: 0.5rem 1.25rem;
     position: relative;
     width: 100%;
   }
 
+  .header > div:first-child {
+    flex: 3 0 auto;
+   }
+
   .content {
     height: 100%;
     overflow: auto;
     padding: 1.25rem;
     width: 100%;
-  }
-
-  .locale {
-    align-self: center;
-    flex: 0 0 auto;
-    padding-right: 1.25rem;
-    position: relative;
-  }
-
-  .bidirectionality {
-    align-self: center;
-    flex: 0 0 auto;
-    position: relative;
-  }
-
-  .utility {
-   display: flex;
-   flex: 1 1 auto;
-   justify-content: flex-end;
-   position: relative;
-   width: 100%;
   }
 
 // Doing a bit of positioning here to override other site styling that the demo does not need


### PR DESCRIPTION
### Summary
Uplifted terra-clinical-site to use the collapsible menu view such that the options collapse at smaller view port sizes. Closes #202.

