### PR TITLE
Removing unnecessary stats file from version control

### DIFF
--- a/packages/terra-clinical-site/.gitignore
+++ b/packages/terra-clinical-site/.gitignore
@@ -1,0 +1,1 @@
+/stats.json

--- a/packages/terra-clinical-site/package.json
+++ b/packages/terra-clinical-site/package.json
@@ -19,7 +19,6 @@
     "compile:build": "babel src --out-dir lib --copy-files",
     "compile:heroku": "webpack --config webpack.prod.config --progress",
     "compile:prod": "webpack --config webpack.prod.config -p",
-    "compile:prod-stats": "webpack --config webpack.prod.config -p --json > stats.json",
     "deploy": "npm run compile:prod && gh-pages -d build",
     "lint": "npm run lint:js",
     "lint:js": "eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",


### PR DESCRIPTION
### Summary
Removing the large stats log for a production build command. Also removing the command altogether.