### PR TITLE
Fix item collection documentation link

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@ Cerner Corporation
 - Tyler Biethman [@tbiethman]
 - Matt Henkes [@mjhenkes]
 - Nikhil Agrawal [@nagrawal3]
+- Gerard Isdell [@gerard-isdell]
 
 [@dkasper-was-taken]: https://github.com/dkasper-was-taken
 [@jmsv6d]: https://github.com/jmsv6d
@@ -15,3 +16,4 @@ Cerner Corporation
 [@tbiethman]: https://github.com/tbiethman
 [@mjhenkes]: https://github.com/mjhenkes
 [@nagrawal3]: https://github.com/nagrawal3
+[@gerard-isdell]: https://github.com/gerard-isdell

--- a/packages/terra-clinical-item-collection/README.md
+++ b/packages/terra-clinical-item-collection/README.md
@@ -8,7 +8,7 @@ An Item Collection is a wrapper component designed to display data as either a t
 Ultimately, the Item Collection component allows consumers to organize tabular data and ensure this data is readable as screen sizes become progressively smaller.
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-clinical-item-collection/docs)
+- [Documentation](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-item-collection/docs)
 - [LICENSE](#license)
 
 ## Getting Started


### PR DESCRIPTION
### Summary
Closes #214 

### Additional Details
Updated broken documentation link to point to https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-item-collection/docs