### PR TITLE
Terra toolkit upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,5 @@
 language: node_js
 sudo: required
-jdk: oraclejdk8
-addons:
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
-      - oracle-java8-set-default
 script:
   - npm test
   - npm run danger
@@ -21,6 +13,9 @@ env:
   global:
     - SAUCE_USERNAME=cerner
     - secure: xbS6srAElIfUiioKUO8IQzGoFhwgI0VXu7yXjMixlJ8FX3pdXCH3w67HtpgdfW/9Uy04N2UmhH6vpmPmuE0geZI/tuMavLYpokvqVWg0SQuA1im28uBuIia65lxrQTrHOxCvrfNT5kjSvuuZ9bASJseh4HpmKbDXz2FszslDstZVvS/pOeO/7qKzS2pgQVO4SLsDveAODzqeUZEllQlsyPjuY90KBSWvxhJ6cB+IglK/8yS/FJMkVFTnFrlAWv10oD9wNiQvOfnn/y0+UjSyFiCJogOoRxAGNPZQ8q6QIWNgquEfL+/Lg0N2B+MHNwimQXg4Nk4yT4nyg7j+wT8eFANnOl9Q84sY1QxMRxtn6CpFNEHX+2zfAsdUEKdhm/mHJxxhEMJcFjlK1FqpJGF/eV5fYXRt2semrk/72l+kApCUPwgohR43pN2B9Fmwnb4ScEL5VaOcsZOeTUlLlZacjcWeW8CpvhEdTU9H1uRzKyqAsnzfEKT+qAontgbvGyuduzykTRuWgR5T4F1NiT0vjJ1XGkX3RoX4mZG0HnagU7Kg3CAoNLvveCPO12m5mHFSeG3W4WD0lI01fICh4dHsipHkHQwTHMw3nd4MoxH4erRqSDfoatfkgY0iNN8rgfCH/5iNgg5jwnyLz4MymgwZt4NzpQGjvDTxP442XHY1AVg=
+before_install:
+  - docker pull selenium/standalone-chrome
+  - docker run -e TZ=America/Chicago -d -p 4444:4444 selenium/standalone-chrome
 before_deploy:
   - lerna run --scope terra-clinical-site compile:prod
 deploy:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@
 
 Please read through our [contributing guidelines](CONTRIBUTING.md). Included are directions for issue reporting and pull requests.
 
+## Local Development
+
+1. Install docker https://www.docker.com/ to run browser tests.
+2. Install dependencies and run tests.
+```sh
+npm install
+npm run test
+```
+
 ## LICENSE
 
 Copyright 2017 Cerner Innovation, Inc.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "stylelint": "~8.0.0",
     "stylelint-config-sass-guidelines": "^3.0.0",
     "terra-props-table": "^1.0.0",
-    "terra-toolkit": "^2.1.0",
+    "terra-toolkit": "^2.2.0",
     "webpack": "^3.6.0",
     "webpack-dev-server": "2.7.1"
   }


### PR DESCRIPTION
### Summary
Upgrades toolkit to 2.2.0. This moves all testing into docker containers and enables webdriver.io testing.
