### PR TITLE
Add postcssassets-plugin

### DIFF
--- a/packages/terra-clinical-application-site/package.json
+++ b/packages/terra-clinical-application-site/package.json
@@ -72,6 +72,7 @@
     "gh-pages": "^0.12.0",
     "html-webpack-plugin": "^2.30.0",
     "node-sass": "^4.5.2",
+    "postcss-assets-webpack-plugin": "^1.1.0",
     "postcss-custom-properties": "^6.0.1",
     "postcss-loader": "^2.0.6",
     "postcss-rtl": "^1.1.2",

--- a/packages/terra-clinical-application-site/webpack.config.js
+++ b/packages/terra-clinical-application-site/webpack.config.js
@@ -9,7 +9,8 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const I18nAggregatorPlugin = require('terra-i18n-plugin');
 const i18nSupportedLocales = require('terra-i18n/lib/i18nSupportedLocales');
-const CustomProperties = require('postcss-custom-properties');
+const PostCSSAssetsPlugin = require('postcss-assets-webpack-plugin');
+const PostCSSCustomProperties = require('postcss-custom-properties');
 const rtl = require('postcss-rtl');
 
 module.exports = {
@@ -49,7 +50,6 @@ module.exports = {
                       'iOS >= 8',
                     ],
                   }),
-                  CustomProperties(),
                   rtl(),
                 ];
               },
@@ -77,6 +77,13 @@ module.exports = {
     new I18nAggregatorPlugin({
       baseDirectory: __dirname,
       supportedLocales: i18nSupportedLocales,
+    }),
+    new PostCSSAssetsPlugin({
+      test: /\.css$/,
+      log: false,
+      plugins: [
+        PostCSSCustomProperties({ preserve: true }),
+      ],
     }),
     new webpack.NamedChunksPlugin(),
   ],

--- a/packages/terra-clinical-site/package.json
+++ b/packages/terra-clinical-site/package.json
@@ -70,6 +70,7 @@
     "gh-pages": "^0.12.0",
     "html-webpack-plugin": "^2.30.0",
     "node-sass": "^4.5.2",
+    "postcss-assets-webpack-plugin": "^1.1.0",
     "postcss-custom-properties": "^6.0.1",
     "postcss-loader": "^2.0.6",
     "postcss-rtl": "^1.1.2",

--- a/packages/terra-clinical-site/postcss.config.js
+++ b/packages/terra-clinical-site/postcss.config.js
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const Autoprefixer = require('autoprefixer');
-const CustomProperties = require('postcss-custom-properties');
 const rtl = require('postcss-rtl');
 
 module.exports = {
@@ -15,7 +14,6 @@ module.exports = {
           'iOS >= 10',
         ],
       }),
-      CustomProperties({ preserve: true, warnings: false }),
       rtl(),
     ];
   },

--- a/packages/terra-clinical-site/webpack.config.js
+++ b/packages/terra-clinical-site/webpack.config.js
@@ -3,6 +3,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const webpack = require('webpack');
 const postCssConfig = require('./postcss.config');
+const PostCSSAssetsPlugin = require('postcss-assets-webpack-plugin');
+const PostCSSCustomProperties = require('postcss-custom-properties');
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -59,6 +61,13 @@ module.exports = {
     new I18nAggregatorPlugin({
       baseDirectory: __dirname,
       supportedLocales: i18nSupportedLocales,
+    }),
+    new PostCSSAssetsPlugin({
+      test: /\.css$/,
+      log: false,
+      plugins: [
+        PostCSSCustomProperties({ preserve: true }),
+      ],
     }),
     new webpack.NamedChunksPlugin(),
   ],


### PR DESCRIPTION
### Summary
* add postcssassets-plugin

This enables us to compile themes using the `:root` selector to static values for testing theming in browsers that lack support for CSS custom properties.

Sync with https://github.com/cerner/terra-core/pull/971

Thanks for contributing to Terra. 
@cerner/terra
