### PR TITLE
Remove flickering initial header background.

### DIFF
--- a/packages/terra-clinical-site/CHANGELOG.md
+++ b/packages/terra-clinical-site/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Place site header background on a parent div, instead of collapsible.
 
 1.5.0 - (November 28, 2017)
 -----------------

--- a/packages/terra-clinical-site/src/App.jsx
+++ b/packages/terra-clinical-site/src/App.jsx
@@ -118,12 +118,14 @@ class App extends React.Component {
     );
 
     const applicationHeader = (
-      <CollapsibleMenuView className={styles.header}>
-        {toggleContent}
-        {localeContent}
-        <CollapsibleMenuView.Divider />
-        {bidiContent}
-      </CollapsibleMenuView>
+      <div className={styles.header}>
+        <CollapsibleMenuView className={styles.collapsible}>
+          {toggleContent}
+          {localeContent}
+          <CollapsibleMenuView.Divider />
+          {bidiContent}
+        </CollapsibleMenuView>
+      </div>
     );
 
     return (

--- a/packages/terra-clinical-site/src/site.scss
+++ b/packages/terra-clinical-site/src/site.scss
@@ -46,7 +46,7 @@
     width: 100%;
   }
 
-  .header > div:first-child {
+  .collapsible > div:first-child {
     flex: 3 0 auto;
    }
 


### PR DESCRIPTION
Summary
Remove sites flickering header background on initial page load, by placing the background on a parent div.

Thanks for contributing to Terra.
@cerner/terra
