### PR TITLE
Item Collection Pass Back View

### DIFF
--- a/packages/terra-clinical-item-collection/CHANGELOG.md
+++ b/packages/terra-clinical-item-collection/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Pass down the Item Collection's view to allow for custom Item Collection components to know when to render as a list item or a table row.
 
 2.0.0 - (November 29, 2017)
 -----------------

--- a/packages/terra-clinical-item-collection/src/_ListView.jsx
+++ b/packages/terra-clinical-item-collection/src/_ListView.jsx
@@ -37,7 +37,7 @@ function createListItems(children, onSelect, requiredElements) {
       return React.cloneElement(child, { view: 'list', ...onSelectProps, ...itemViewPieces });
     }
 
-    return child;
+    return React.cloneElement(child, { view: 'list' });
   });
 }
 

--- a/packages/terra-clinical-item-collection/src/_TableView.jsx
+++ b/packages/terra-clinical-item-collection/src/_TableView.jsx
@@ -62,7 +62,7 @@ function createTableRows(children, onSelect, requiredElements) {
       return React.cloneElement(child, { view: 'table', ...onSelectProps, ...tableRowPieces });
     }
 
-    return child;
+    return React.cloneElement(child, { view: 'table' });
   });
 }
 


### PR DESCRIPTION
### Summary
This change passes the Item Collection's view to any custom component that is passed into the Item Collection. This allows custom component to know when to render as a list item or a table row.

