### PR TITLE
[Item Collection] Add Chevron Prop & Expose IC Generated Props

### DIFF
--- a/packages/terra-clinical-item-collection/CHANGELOG.md
+++ b/packages/terra-clinical-item-collection/CHANGELOG.md
@@ -3,6 +3,11 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* showListItemChevron prop on the ItemCollection.Item component to allow list items to display a chevron.
+
+### Changed
+* Remove type check to pass all Item Collection generated properties that are passed to the Item Collection children
 
 2.1.0 - (December 5, 2017)
 -----------------

--- a/packages/terra-clinical-item-collection/src/Item.jsx
+++ b/packages/terra-clinical-item-collection/src/Item.jsx
@@ -48,7 +48,8 @@ const propTypes = {
    */
   reserveStartAccessorySpace: PropTypes.bool,
   /**
-   * When displayed as a list item, whether or not it has a chevron.
+   * When displayed as a list item, whether or not it has a chevron. This should only be used when creating a
+   * a single selectable list.
    */
   showListItemChevron: PropTypes.bool,
   /**

--- a/packages/terra-clinical-item-collection/src/Item.jsx
+++ b/packages/terra-clinical-item-collection/src/Item.jsx
@@ -48,6 +48,10 @@ const propTypes = {
    */
   reserveStartAccessorySpace: PropTypes.bool,
   /**
+   * When displayed as a list item, whether or not it has a chevron.
+   */
+  showListItemChevron: PropTypes.bool,
+  /**
    * Whether or not the item is selectable. If true, the item is given list and table hover and focus styles
    * and set tabIndex to 0.
    */
@@ -74,10 +78,11 @@ const defaultProps = {
   listItemLayout: 'oneColumn',
   listItemTextEmphasis: 'default',
   reserveStartAccessorySpace: false,
+  showListItemChevron: false,
   view: 'list',
 };
 
-function createListItem(elements, selectableProps, customProps, isSelected, itemViewStyles) {
+function createListItem(elements, selectableProps, customProps, isSelected, itemViewStyles, showListItemChevron) {
   const { startAccessory, children, comment, endAccessory, reserveStartAccessorySpace } = elements;
 
   const listItemContent = (
@@ -95,6 +100,7 @@ function createListItem(elements, selectableProps, customProps, isSelected, item
     <List.Item
       content={listItemContent}
       isSelected={isSelected}
+      hasChevron={showListItemChevron}
       {...selectableProps}
       {...customProps}
     />
@@ -143,6 +149,7 @@ const Item = (props) => {
     listItemLayout,
     listItemTextEmphasis,
     reserveStartAccessorySpace,
+    showListItemChevron,
     view,
     ...customProps
   } = props;
@@ -155,7 +162,7 @@ const Item = (props) => {
   }
 
   const itemViewStyles = { layout: listItemLayout, textEmphasis: listItemTextEmphasis, isTruncated: isListItemTruncated, accessoryAlignment };
-  return createListItem(elements, selectableProps, customProps, isSelected, itemViewStyles);
+  return createListItem(elements, selectableProps, customProps, isSelected, itemViewStyles, showListItemChevron);
 };
 
 Item.propTypes = propTypes;

--- a/packages/terra-clinical-item-collection/src/_ListView.jsx
+++ b/packages/terra-clinical-item-collection/src/_ListView.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import List from 'terra-list';
-import Item from './Item';
 import Utils from './_ItemCollectionUtils';
 
 const propTypes = {
@@ -31,13 +30,9 @@ const propTypes = {
 
 function createListItems(children, onSelect, requiredElements) {
   return React.Children.map(children, (child) => {
-    if (child.type === Item) {
-      const itemViewPieces = Utils.addMissingListElements(child.props, requiredElements);
-      const onSelectProps = onSelect && child.props.isSelectable ? Utils.createOnSelectProps(onSelect, child.key) : {};
-      return React.cloneElement(child, { view: 'list', ...onSelectProps, ...itemViewPieces });
-    }
-
-    return React.cloneElement(child, { view: 'list' });
+    const itemViewPieces = Utils.addMissingListElements(child.props, requiredElements);
+    const onSelectProps = onSelect && child.props.isSelectable ? Utils.createOnSelectProps(onSelect, child.key) : {};
+    return React.cloneElement(child, { view: 'list', ...onSelectProps, ...itemViewPieces });
   });
 }
 

--- a/packages/terra-clinical-item-collection/src/_TableView.jsx
+++ b/packages/terra-clinical-item-collection/src/_TableView.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Table from 'terra-table';
-import Item from './Item';
 import Utils from './_ItemCollectionUtils';
 import styles from './ItemCollection.scss';
 
@@ -56,13 +55,9 @@ function createTableLayout(requiredElements) {
 
 function createTableRows(children, onSelect, requiredElements) {
   return React.Children.map(children, (child) => {
-    if (child.type === Item) {
-      const tableRowPieces = Utils.addMissingTableElements(child.props, requiredElements);
-      const onSelectProps = onSelect && child.props.isSelectable ? Utils.createOnSelectProps(onSelect, child.key) : {};
-      return React.cloneElement(child, { view: 'table', ...onSelectProps, ...tableRowPieces });
-    }
-
-    return React.cloneElement(child, { view: 'table' });
+    const tableRowPieces = Utils.addMissingTableElements(child.props, requiredElements);
+    const onSelectProps = onSelect && child.props.isSelectable ? Utils.createOnSelectProps(onSelect, child.key) : {};
+    return React.cloneElement(child, { view: 'table', ...onSelectProps, ...tableRowPieces });
   });
 }
 

--- a/packages/terra-clinical-item-collection/tests/jest/Item.test.jsx
+++ b/packages/terra-clinical-item-collection/tests/jest/Item.test.jsx
@@ -149,6 +149,24 @@ describe('List View Tests', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('should render a Item with a list item chevron', () => {
+    const item = (
+      <Item
+        view="list"
+        startAccessory={<p>start</p>}
+        comment={<Item.Comment text="comment" />}
+        endAccessory={<p>end</p>}
+        showListItemChevron
+      >
+        <Item.Display text="Display 1" />
+        <Item.Display text="Display 2" />
+        <Item.Display text="Display 3" />
+      </Item>
+    );
+    const component = shallow(item);
+    expect(component).toMatchSnapshot();
+  });
+
   it('should pass customProps to the Item', () => {
     const item = (
       <Item
@@ -288,6 +306,24 @@ describe('Table View Tests', () => {
         comment={<Item.Comment text="comment" />}
         endAccessory={<p>end</p>}
         {...listItemStyles}
+      >
+        <Item.Display text="Display 1" />
+        <Item.Display text="Display 2" />
+        <Item.Display text="Display 3" />
+      </Item>
+    );
+    const component = shallow(item);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should render a Item that ignores the list item chevron', () => {
+    const item = (
+      <Item
+        view="list"
+        startAccessory={<p>start</p>}
+        comment={<Item.Comment text="comment" />}
+        endAccessory={<p>end</p>}
+        showListItemChevron
       >
         <Item.Display text="Display 1" />
         <Item.Display text="Display 2" />

--- a/packages/terra-clinical-item-collection/tests/jest/__snapshots__/Item.test.jsx.snap
+++ b/packages/terra-clinical-item-collection/tests/jest/__snapshots__/Item.test.jsx.snap
@@ -25,6 +25,7 @@ exports[`List View Tests should pass customProps to the Item 1`] = `
       textEmphasis="default"
     />
   }
+  hasChevron={false}
   isSelected={false}
 />
 `;
@@ -49,6 +50,61 @@ exports[`List View Tests should render a Item with a comment 1`] = `
       textEmphasis="default"
     />
   }
+  hasChevron={false}
+  isSelected={false}
+/>
+`;
+
+exports[`List View Tests should render a Item with a list item chevron 1`] = `
+<ListItem
+  content={
+    <ItemView
+      accessoryAlignment="alignCenter"
+      comment={
+        <ItemComment
+          isTruncated={false}
+          text="comment"
+        />
+      }
+      displays={
+        Array [
+          <ItemDisplay
+            icon={undefined}
+            isTruncated={false}
+            text="Display 1"
+            textStyle={undefined}
+          />,
+          <ItemDisplay
+            icon={undefined}
+            isTruncated={false}
+            text="Display 2"
+            textStyle={undefined}
+          />,
+          <ItemDisplay
+            icon={undefined}
+            isTruncated={false}
+            text="Display 3"
+            textStyle={undefined}
+          />,
+        ]
+      }
+      endAccessory={
+        <p>
+          end
+        </p>
+      }
+      isTruncated={false}
+      layout="oneColumn"
+      reserveStartAccessorySpace={false}
+      startAccessory={
+        <p>
+          start
+        </p>
+      }
+      textEmphasis="default"
+    />
+  }
+  hasChevron={true}
   isSelected={false}
 />
 `;
@@ -77,6 +133,7 @@ exports[`List View Tests should render a Item with a single children 1`] = `
       textEmphasis="default"
     />
   }
+  hasChevron={false}
   isSelected={false}
 />
 `;
@@ -100,6 +157,7 @@ exports[`List View Tests should render a Item with a start accessory 1`] = `
       textEmphasis="default"
     />
   }
+  hasChevron={false}
   isSelected={false}
 />
 `;
@@ -153,6 +211,7 @@ exports[`List View Tests should render a Item with all elements 1`] = `
       textEmphasis="default"
     />
   }
+  hasChevron={false}
   isSelected={false}
 />
 `;
@@ -176,6 +235,7 @@ exports[`List View Tests should render a Item with an end accessory 1`] = `
       textEmphasis="default"
     />
   }
+  hasChevron={false}
   isSelected={false}
 />
 `;
@@ -216,6 +276,7 @@ exports[`List View Tests should render a Item with children 1`] = `
       textEmphasis="default"
     />
   }
+  hasChevron={false}
   isSelected={false}
 />
 `;
@@ -269,6 +330,7 @@ exports[`List View Tests should render a Item with list item styles 1`] = `
       textEmphasis="start"
     />
   }
+  hasChevron={false}
   isSelected={false}
 />
 `;
@@ -288,6 +350,7 @@ exports[`List View Tests should render a default Item 1`] = `
       textEmphasis="default"
     />
   }
+  hasChevron={false}
   isSelected={false}
 />
 `;
@@ -341,6 +404,7 @@ exports[`List View Tests should render a selectable Item 1`] = `
       textEmphasis="default"
     />
   }
+  hasChevron={false}
   isSelectable={true}
   isSelected={false}
   tabIndex={0}
@@ -507,6 +571,60 @@ exports[`Table View Tests should render a Item that ignores list item styles 1`]
     key="end_accessory"
   />
 </TableRow>
+`;
+
+exports[`Table View Tests should render a Item that ignores the list item chevron 1`] = `
+<ListItem
+  content={
+    <ItemView
+      accessoryAlignment="alignCenter"
+      comment={
+        <ItemComment
+          isTruncated={false}
+          text="comment"
+        />
+      }
+      displays={
+        Array [
+          <ItemDisplay
+            icon={undefined}
+            isTruncated={false}
+            text="Display 1"
+            textStyle={undefined}
+          />,
+          <ItemDisplay
+            icon={undefined}
+            isTruncated={false}
+            text="Display 2"
+            textStyle={undefined}
+          />,
+          <ItemDisplay
+            icon={undefined}
+            isTruncated={false}
+            text="Display 3"
+            textStyle={undefined}
+          />,
+        ]
+      }
+      endAccessory={
+        <p>
+          end
+        </p>
+      }
+      isTruncated={false}
+      layout="oneColumn"
+      reserveStartAccessorySpace={false}
+      startAccessory={
+        <p>
+          start
+        </p>
+      }
+      textEmphasis="default"
+    />
+  }
+  hasChevron={true}
+  isSelected={false}
+/>
 `;
 
 exports[`Table View Tests should render a Item with a comment 1`] = `
@@ -856,6 +974,7 @@ exports[`should render a default Item 1`] = `
       textEmphasis="default"
     />
   }
+  hasChevron={false}
   isSelected={false}
 />
 `;

--- a/packages/terra-clinical-item-collection/tests/jest/__snapshots__/ItemCollection.test.jsx.snap
+++ b/packages/terra-clinical-item-collection/tests/jest/__snapshots__/ItemCollection.test.jsx.snap
@@ -34,6 +34,7 @@ exports[`should render an ItemCollection with a breakpoint 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -96,6 +97,7 @@ exports[`should render an ItemCollection with a breakpoint 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -157,6 +159,7 @@ exports[`should render an ItemCollection with a comment 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={undefined}
         view="list"
       />
@@ -192,6 +195,7 @@ exports[`should render an ItemCollection with a comment 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={undefined}
         view="list"
       />
@@ -225,6 +229,7 @@ exports[`should render an ItemCollection with a start accessory 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -259,6 +264,7 @@ exports[`should render an ItemCollection with a start accessory 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -305,6 +311,7 @@ exports[`should render an ItemCollection with all elements 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -355,6 +362,7 @@ exports[`should render an ItemCollection with all elements 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -403,6 +411,7 @@ exports[`should render an ItemCollection with an end accessory 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={undefined}
         view="list"
       />
@@ -437,6 +446,7 @@ exports[`should render an ItemCollection with an end accessory 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={undefined}
         view="list"
       />
@@ -479,6 +489,7 @@ exports[`should render an ItemCollection with displays 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -529,6 +540,7 @@ exports[`should render an ItemCollection with displays 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -582,6 +594,7 @@ exports[`should render an ItemCollection with list styles 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -644,6 +657,7 @@ exports[`should render an ItemCollection with list styles 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -709,6 +723,7 @@ exports[`should render an ItemCollection with onSelect 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -760,6 +775,7 @@ exports[`should render an ItemCollection with onSelect 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -814,6 +830,7 @@ exports[`should render an ItemCollection with table styles 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -876,6 +893,7 @@ exports[`should render an ItemCollection with table styles 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={
           <p>
             S
@@ -932,6 +950,7 @@ exports[`should render an default ItemCollection with no elements 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={undefined}
         view="list"
       />
@@ -962,6 +981,7 @@ exports[`should render an default ItemCollection with no elements 1`] = `
         listItemLayout="oneColumn"
         listItemTextEmphasis="default"
         reserveStartAccessorySpace={false}
+        showListItemChevron={false}
         startAccessory={undefined}
         view="list"
       />

--- a/packages/terra-clinical-item-collection/tests/jest/__snapshots__/_ListView.test.jsx.snap
+++ b/packages/terra-clinical-item-collection/tests/jest/__snapshots__/_ListView.test.jsx.snap
@@ -25,6 +25,7 @@ exports[`should render a ListView with a divided list 1`] = `
     listItemLayout="oneColumn"
     listItemTextEmphasis="default"
     reserveStartAccessorySpace={true}
+    showListItemChevron={false}
     startAccessory={
       <p>
         S
@@ -65,6 +66,7 @@ exports[`should render a ListView with children 1`] = `
     listItemLayout="oneColumn"
     listItemTextEmphasis="default"
     reserveStartAccessorySpace={true}
+    showListItemChevron={false}
     startAccessory={
       <p>
         S

--- a/packages/terra-clinical-item-collection/tests/jest/__snapshots__/_TableView.test.jsx.snap
+++ b/packages/terra-clinical-item-collection/tests/jest/__snapshots__/_TableView.test.jsx.snap
@@ -71,6 +71,7 @@ exports[`should render a TableView with children 1`] = `
       listItemLayout="oneColumn"
       listItemTextEmphasis="default"
       reserveStartAccessorySpace={false}
+      showListItemChevron={false}
       startAccessory={
         <p>
           S
@@ -165,6 +166,7 @@ exports[`should render a TableView with table styles 1`] = `
       listItemLayout="oneColumn"
       listItemTextEmphasis="default"
       reserveStartAccessorySpace={false}
+      showListItemChevron={false}
       startAccessory={
         <p>
           S

--- a/packages/terra-clinical-item-collection/tests/nightwatch/item-collection/ItemCollectionSelectable.jsx
+++ b/packages/terra-clinical-item-collection/tests/nightwatch/item-collection/ItemCollectionSelectable.jsx
@@ -36,6 +36,7 @@ class DefaultItemCollection extends React.Component {
             startAccessory={<ItemCollection.Comment />}
             comment={<ItemCollection.Comment text="test comment" />}
             endAccessory={<button size="medium">Disclose</button>}
+            showListItemChevron
           >
             <ItemCollection.Display text="Display 1" />
             <ItemCollection.Display text="Display 1" />
@@ -48,6 +49,7 @@ class DefaultItemCollection extends React.Component {
             isSelectable
             comment={<ItemCollection.Comment text="test comment" />}
             endAccessory={<button size="medium">Disclose</button>}
+            showListItemChevron
           >
             <ItemCollection.Display text="Display 1" />
             <ItemCollection.Display text="Display 1" />


### PR DESCRIPTION
### Summary
* Add `showListItemChevron` prop to allow list items to display a chevron
* Expose all Item Collection generated props that are passed to the children when generating a list or table view
