### PR TITLE
Lock down docker-selenium Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ cache:
   directories:
     - node_modules
 before_install:
-  - docker pull selenium/standalone-chrome
-  - docker run -v /dev/shm:/dev/shm -e TZ=America/Chicago -d -p 4444:4444 selenium/standalone-chrome
+  - docker pull selenium/standalone-chrome:3.8.1-erbium
+  - docker run -v /dev/shm:/dev/shm -e TZ=America/Chicago -d -p 4444:4444 selenium/standalone-chrome:3.8.1-erbium
 before_deploy:
   - lerna run --scope terra-clinical-site compile:prod
 deploy:

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "stylelint": "~8.0.0",
     "stylelint-config-sass-guidelines": "^3.0.0",
     "terra-props-table": "^1.0.0",
-    "terra-toolkit": "^2.3.0",
+    "terra-toolkit": "git://github.com/cerner/terra-toolkit.git#fix-tests",
     "wdio-mocha-framework": "^0.5.11",
     "wdio-visual-regression-service": "^0.8.0",
     "webdriverio": "^4.9.8",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "stylelint": "~8.0.0",
     "stylelint-config-sass-guidelines": "^3.0.0",
     "terra-props-table": "^1.0.0",
-    "terra-toolkit": "git://github.com/cerner/terra-toolkit.git#fix-tests",
+    "terra-toolkit": "^2.7.0",
     "wdio-mocha-framework": "^0.5.11",
     "wdio-visual-regression-service": "^0.8.0",
     "webdriverio": "^4.9.8",

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -34,6 +34,16 @@ const config = {
     },
   },
 
+  axe: {
+    inject: true,
+    options: {
+      rules: [{
+        id: 'landmark-one-main',
+        enabled: false,
+      }],
+    },
+  },
+
    // Configuration for WebPackDevService
   webpackPort,
   webpackConfig,


### PR DESCRIPTION
Two days ago docker-selenium [released a new version](https://github.com/SeleniumHQ/docker-selenium/commit/cfc1eeb5cdcea02395016685d7012688768ed342) of both selenium/node-chrome and selenium/standalone-chrome. In our tests we pull in the latest tag of both.

The previous version is `3.8.1-erbium` and the latest release is `3.8.1-francium`. 

This pulls the previous version to see if this resolves the issues we are seeing with the repeated
` Expected element ' ' to be present - element was not found`