### PR TITLE
Replace status emoji with shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,28 +18,27 @@
 ## Packages
 
 ### Status
-:white_check_mark: Stable
-:large_orange_diamond: Beta
-:construction: In Progress
-:x: Deprecated
+![Stable](https://img.shields.io/badge/status-Stable-brightgreen.svg)
+![Stable](https://img.shields.io/badge/status-Beta-orange.svg)
+![Stable](https://img.shields.io/badge/status-Deprecated-lightgrey.svg)
 
 
 | Terra Package      | Version | Status |
 |--------------------|---------|--------|
-| [terra-clinical-action-header](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-action-header) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-action-header.svg)](https://www.npmjs.org/package/terra-clinical-action-header) | :white_check_mark:|
-| terra-clinical-app-delegate |[![NPM version](http://img.shields.io/npm/v/terra-clinical-app-delegate.svg)](https://www.npmjs.org/package/terra-clinical-app-delegate) | :x:|
-| [terra-clinical-application](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-application) |[![NPM version](http://img.shields.io/npm/v/terra-clinical-application.svg)](https://www.npmjs.org/package/terra-clinical-application) | :white_check_mark:|
-| [terra-clinical-detail-view](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-detail-view) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-detail-view.svg)](https://www.npmjs.org/package/terra-clinical-detail-view) | :white_check_mark: |
-| [terra-clinical-error-view](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-error-view) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-error-view.svg)](https://www.npmjs.org/package/terra-clinical-error-view) | :x:|
-| [terra-clinical-header](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-header) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-header.svg)](https://www.npmjs.org/package/terra-clinical-header) | :white_check_mark: |
-| [terra-clinical-item-collection](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-item-collection) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-item-collection.svg)](https://www.npmjs.org/package/terra-clinical-item-collection) | :white_check_mark: |
-| [terra-clinical-item-display](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-item-display)  | [![NPM version](http://img.shields.io/npm/v/terra-clinical-item-display.svg)](https://www.npmjs.org/package/terra-clinical-item-display) | :white_check_mark: |
-| [terra-clinical-item-view](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-item-view) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-item-view.svg)](https://www.npmjs.org/package/terra-clinical-item-view) | :white_check_mark: |
-| [terra-clinical-label-value-view](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-label-value-view) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-label-value-view.svg)](https://www.npmjs.org/package/terra-clinical-label-value-view) | :white_check_mark: |
-| terra-clinical-modal-manager |[![NPM version](http://img.shields.io/npm/v/terra-clinical-modal-manager.svg)](https://www.npmjs.org/package/terra-clinical-modal-manager) | :x:|
-| [terra-clinical-no-data-view](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-no-data-view) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-no-data-view.svg)](https://www.npmjs.org/package/terra-clinical-no-data-view) | :x:|
-| [terra-clinical-site](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-site) |[![NPM version](http://img.shields.io/npm/v/terra-clinical-site.svg)](https://www.npmjs.org/package/terra-clinical-site) | :white_check_mark:|
-| terra-clinical-slide-group |[![NPM version](http://img.shields.io/npm/v/terra-clinical-slide-group.svg)](https://www.npmjs.org/package/terra-clinical-slide-group) | :x:|
+| [terra-clinical-action-header](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-action-header) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-action-header.svg)](https://www.npmjs.org/package/terra-clinical-action-header) | ![Stable](https://img.shields.io/badge/status-Stable-brightgreen.svg)|
+| terra-clinical-app-delegate |[![NPM version](http://img.shields.io/npm/v/terra-clinical-app-delegate.svg)](https://www.npmjs.org/package/terra-clinical-app-delegate) | ![Stable](https://img.shields.io/badge/status-Deprecated-lightgrey.svg)|
+| [terra-clinical-application](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-application) |[![NPM version](http://img.shields.io/npm/v/terra-clinical-application.svg)](https://www.npmjs.org/package/terra-clinical-application) | ![Stable](https://img.shields.io/badge/status-Stable-brightgreen.svg)|
+| [terra-clinical-detail-view](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-detail-view) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-detail-view.svg)](https://www.npmjs.org/package/terra-clinical-detail-view) | ![Stable](https://img.shields.io/badge/status-Stable-brightgreen.svg) |
+| [terra-clinical-error-view](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-error-view) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-error-view.svg)](https://www.npmjs.org/package/terra-clinical-error-view) | ![Stable](https://img.shields.io/badge/status-Deprecated-lightgrey.svg)|
+| [terra-clinical-header](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-header) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-header.svg)](https://www.npmjs.org/package/terra-clinical-header) | ![Stable](https://img.shields.io/badge/status-Stable-brightgreen.svg) |
+| [terra-clinical-item-collection](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-item-collection) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-item-collection.svg)](https://www.npmjs.org/package/terra-clinical-item-collection) | ![Stable](https://img.shields.io/badge/status-Stable-brightgreen.svg) |
+| [terra-clinical-item-display](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-item-display)  | [![NPM version](http://img.shields.io/npm/v/terra-clinical-item-display.svg)](https://www.npmjs.org/package/terra-clinical-item-display) | ![Stable](https://img.shields.io/badge/status-Stable-brightgreen.svg) |
+| [terra-clinical-item-view](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-item-view) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-item-view.svg)](https://www.npmjs.org/package/terra-clinical-item-view) | ![Stable](https://img.shields.io/badge/status-Stable-brightgreen.svg) |
+| [terra-clinical-label-value-view](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-label-value-view) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-label-value-view.svg)](https://www.npmjs.org/package/terra-clinical-label-value-view) | ![Stable](https://img.shields.io/badge/status-Stable-brightgreen.svg) |
+| terra-clinical-modal-manager |[![NPM version](http://img.shields.io/npm/v/terra-clinical-modal-manager.svg)](https://www.npmjs.org/package/terra-clinical-modal-manager) | ![Stable](https://img.shields.io/badge/status-Deprecated-lightgrey.svg)|
+| [terra-clinical-no-data-view](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-no-data-view) | [![NPM version](http://img.shields.io/npm/v/terra-clinical-no-data-view.svg)](https://www.npmjs.org/package/terra-clinical-no-data-view) | ![Stable](https://img.shields.io/badge/status-Deprecated-lightgrey.svg)|
+| [terra-clinical-site](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-site) |[![NPM version](http://img.shields.io/npm/v/terra-clinical-site.svg)](https://www.npmjs.org/package/terra-clinical-site) | ![Stable](https://img.shields.io/badge/status-Stable-brightgreen.svg)|
+| terra-clinical-slide-group |[![NPM version](http://img.shields.io/npm/v/terra-clinical-slide-group.svg)](https://www.npmjs.org/package/terra-clinical-slide-group) | ![Stable](https://img.shields.io/badge/status-Deprecated-lightgrey.svg)|
 
 
 ## Supported Browsers


### PR DESCRIPTION
### Summary
Emoji do not render in our static deployed site. This PR replaces the status emoji with shields (which are externally hosted) to keep the read me consistent across deployments of the site.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
