### PR TITLE
Add option to display close button on small viewports

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ Cerner Corporation
 - Noah Benham [@noahbenham]
 - Natalie Seeto [@njseeto]
 - Kevin Schuster [@kschuste]
+- Yusuf Ali [@yusufali2205]
 
 [@dkasper-was-taken]: https://github.com/dkasper-was-taken
 [@jmsv6d]: https://github.com/jmsv6d
@@ -27,3 +28,4 @@ Cerner Corporation
 [@noahbenham]: https://github.com/noahbenham
 [@njseeto]: https://github.com/njseeto
 [@kschuste]: https://github.com/kschuste
+[@yusufali2205]: https://github.com/yusufali2205

--- a/packages/terra-clinical-action-header/CHANGELOG.md
+++ b/packages/terra-clinical-action-header/CHANGELOG.md
@@ -4,7 +4,7 @@ ChangeLog
 Unreleased
 ----------
 ### Added
-* prop to keep the close button in small viewports
+* prop `keepCloseButton` to keep the close button in small viewports
 
 1.6.0 - (December 9, 2017)
 ----------

--- a/packages/terra-clinical-action-header/CHANGELOG.md
+++ b/packages/terra-clinical-action-header/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* prop to keep the close button in small viewports
 
 1.6.0 - (December 9, 2017)
 ----------

--- a/packages/terra-clinical-action-header/src/ActionHeader.jsx
+++ b/packages/terra-clinical-action-header/src/ActionHeader.jsx
@@ -58,6 +58,11 @@ const propTypes = {
   onPrevious: PropTypes.func,
 
   /**
+   * A Boolean indicating if close button should be displayed on small viewports when separate onBack callback is not set.
+   */
+  keepCloseButton: PropTypes.bool,
+
+  /**
    * Child element to be displayed on the right end of the header.
    * This is intended to be used with the CollapsibleMenuView.
    */
@@ -72,6 +77,7 @@ const defaultProps = {
   onMinimize: null,
   onNext: null,
   onPrevious: null,
+  keepCloseButton: null,
   children: null,
 };
 
@@ -92,6 +98,7 @@ const ActionHeader = ({
   onMinimize,
   onPrevious,
   onNext,
+  keepCloseButton,
   children,
   ...customProps }, {
   intl,
@@ -109,7 +116,7 @@ const ActionHeader = ({
 
   let closeButtonSmall;
   let backButtonSmall;
-  if (onClose && !onBack) {
+  if (onClose && !onBack && !keepCloseButton) {
     backButtonSmall = <Button icon={<IconLeft />} aria-label={backText} onClick={onClose} />;
     closeButtonSmall = null;
   } else {

--- a/packages/terra-clinical-action-header/src/ActionHeader.jsx
+++ b/packages/terra-clinical-action-header/src/ActionHeader.jsx
@@ -77,7 +77,7 @@ const defaultProps = {
   onMinimize: null,
   onNext: null,
   onPrevious: null,
-  keepCloseButton: null,
+  keepCloseButton: false,
   children: null,
 };
 

--- a/packages/terra-clinical-action-header/tests/jest/__snapshots__/ActionHeader.test.jsx.snap
+++ b/packages/terra-clinical-action-header/tests/jest/__snapshots__/ActionHeader.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`should render ActionHeader with Previous-Next button when onNext is givien 1`] = `
 <ActionHeader
+  keepCloseButton={null}
   onBack={null}
   onClose={null}
   onMaximize={null}
@@ -14,6 +15,7 @@ exports[`should render ActionHeader with Previous-Next button when onNext is giv
 
 exports[`should render ActionHeader with Previous-Next button when onPrevious is givien 1`] = `
 <ActionHeader
+  keepCloseButton={null}
   onBack={null}
   onClose={null}
   onMaximize={null}
@@ -26,6 +28,7 @@ exports[`should render ActionHeader with Previous-Next button when onPrevious is
 
 exports[`should render ActionHeader with back button 1`] = `
 <ActionHeader
+  keepCloseButton={null}
   onBack={[Function]}
   onClose={null}
   onMaximize={null}
@@ -38,6 +41,7 @@ exports[`should render ActionHeader with back button 1`] = `
 
 exports[`should render ActionHeader with children 1`] = `
 <ActionHeader
+  keepCloseButton={null}
   onBack={null}
   onClose={null}
   onMaximize={null}
@@ -59,6 +63,7 @@ exports[`should render ActionHeader with children 1`] = `
 
 exports[`should render ActionHeader with close button 1`] = `
 <ActionHeader
+  keepCloseButton={null}
   onBack={null}
   onClose={[Function]}
   onMaximize={null}
@@ -71,6 +76,7 @@ exports[`should render ActionHeader with close button 1`] = `
 
 exports[`should render ActionHeader with expand button 1`] = `
 <ActionHeader
+  keepCloseButton={null}
   onBack={null}
   onClose={null}
   onMaximize={[Function]}
@@ -83,6 +89,7 @@ exports[`should render ActionHeader with expand button 1`] = `
 
 exports[`should render ActionHeader with minimize button 1`] = `
 <ActionHeader
+  keepCloseButton={null}
   onBack={null}
   onClose={null}
   onMaximize={null}
@@ -95,6 +102,7 @@ exports[`should render ActionHeader with minimize button 1`] = `
 
 exports[`should render ActionHeader with title 1`] = `
 <ActionHeader
+  keepCloseButton={null}
   onBack={null}
   onClose={null}
   onMaximize={null}
@@ -107,6 +115,7 @@ exports[`should render ActionHeader with title 1`] = `
 
 exports[`should render default component 1`] = `
 <ActionHeader
+  keepCloseButton={null}
   onBack={null}
   onClose={null}
   onMaximize={null}

--- a/packages/terra-clinical-action-header/tests/jest/__snapshots__/ActionHeader.test.jsx.snap
+++ b/packages/terra-clinical-action-header/tests/jest/__snapshots__/ActionHeader.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`should render ActionHeader with Previous-Next button when onNext is givien 1`] = `
 <ActionHeader
-  keepCloseButton={null}
+  keepCloseButton={false}
   onBack={null}
   onClose={null}
   onMaximize={null}
@@ -15,7 +15,7 @@ exports[`should render ActionHeader with Previous-Next button when onNext is giv
 
 exports[`should render ActionHeader with Previous-Next button when onPrevious is givien 1`] = `
 <ActionHeader
-  keepCloseButton={null}
+  keepCloseButton={false}
   onBack={null}
   onClose={null}
   onMaximize={null}
@@ -28,7 +28,7 @@ exports[`should render ActionHeader with Previous-Next button when onPrevious is
 
 exports[`should render ActionHeader with back button 1`] = `
 <ActionHeader
-  keepCloseButton={null}
+  keepCloseButton={false}
   onBack={[Function]}
   onClose={null}
   onMaximize={null}
@@ -41,7 +41,7 @@ exports[`should render ActionHeader with back button 1`] = `
 
 exports[`should render ActionHeader with children 1`] = `
 <ActionHeader
-  keepCloseButton={null}
+  keepCloseButton={false}
   onBack={null}
   onClose={null}
   onMaximize={null}
@@ -63,7 +63,7 @@ exports[`should render ActionHeader with children 1`] = `
 
 exports[`should render ActionHeader with close button 1`] = `
 <ActionHeader
-  keepCloseButton={null}
+  keepCloseButton={false}
   onBack={null}
   onClose={[Function]}
   onMaximize={null}
@@ -76,7 +76,7 @@ exports[`should render ActionHeader with close button 1`] = `
 
 exports[`should render ActionHeader with expand button 1`] = `
 <ActionHeader
-  keepCloseButton={null}
+  keepCloseButton={false}
   onBack={null}
   onClose={null}
   onMaximize={[Function]}
@@ -89,7 +89,7 @@ exports[`should render ActionHeader with expand button 1`] = `
 
 exports[`should render ActionHeader with minimize button 1`] = `
 <ActionHeader
-  keepCloseButton={null}
+  keepCloseButton={false}
   onBack={null}
   onClose={null}
   onMaximize={null}
@@ -102,7 +102,7 @@ exports[`should render ActionHeader with minimize button 1`] = `
 
 exports[`should render ActionHeader with title 1`] = `
 <ActionHeader
-  keepCloseButton={null}
+  keepCloseButton={false}
   onBack={null}
   onClose={null}
   onMaximize={null}
@@ -115,7 +115,7 @@ exports[`should render ActionHeader with title 1`] = `
 
 exports[`should render default component 1`] = `
 <ActionHeader
-  keepCloseButton={null}
+  keepCloseButton={false}
   onBack={null}
   onClose={null}
   onMaximize={null}

--- a/packages/terra-clinical-action-header/tests/nightwatch/ActionHeaderTestRoutes.jsx
+++ b/packages/terra-clinical-action-header/tests/nightwatch/ActionHeaderTestRoutes.jsx
@@ -12,6 +12,7 @@ import MinimizeActionHeader from './MinimizeActionHeader';
 import BackCloseActionHeader from './BackCloseActionHeader';
 import PreviousNextActionHeader from './PreviousNextActionHeader';
 import ChildrenActionHeader from './ChildrenActionHeader';
+import KeepCloseButtonActionHeader from './KeepCloseButtonActionHeader';
 
 const routes = (
   <div>
@@ -22,6 +23,7 @@ const routes = (
     <Route path="/tests/action-header-tests/action-header-minimize" component={MinimizeActionHeader} />
     <Route path="/tests/action-header-tests/action-header-back" component={BackActionHeader} />
     <Route path="/tests/action-header-tests/action-header-close" component={CloseActionHeader} />
+    <Route path="/tests/action-header-tests/action-header-keep-close-button" component={KeepCloseButtonActionHeader} />
     <Route path="/tests/action-header-tests/action-header-back-close" component={BackCloseActionHeader} />
     <Route path="/tests/action-header-tests/action-header-previous-next" component={PreviousNextActionHeader} />
     <Route path="/tests/action-header-tests/action-header-child" component={ChildrenActionHeader} />

--- a/packages/terra-clinical-action-header/tests/nightwatch/ActionHeaderTests.jsx
+++ b/packages/terra-clinical-action-header/tests/nightwatch/ActionHeaderTests.jsx
@@ -12,6 +12,7 @@ const ActionHeaderTests = () => (
       <li><Link to="/tests/action-header-tests/action-header-minimize">ActionHeader - Minimize</Link></li>
       <li><Link to="/tests/action-header-tests/action-header-back">ActionHeader - Back</Link></li>
       <li><Link to="/tests/action-header-tests/action-header-close">ActionHeader - Close</Link></li>
+      <li><Link to="/tests/action-header-tests/action-header-keep-close-button">ActionHeader - Keep Close Button</Link></li>
       <li><Link to="/tests/action-header-tests/action-header-back-close">ActionHeader - Back and Close</Link></li>
       <li><Link to="/tests/action-header-tests/action-header-previous-next">ActionHeader - Previous-Next</Link></li>
       <li><Link to="/tests/action-header-tests/action-header-child">ActionHeader - Custom Content</Link></li>

--- a/packages/terra-clinical-action-header/tests/nightwatch/KeepCloseButtonActionHeader.jsx
+++ b/packages/terra-clinical-action-header/tests/nightwatch/KeepCloseButtonActionHeader.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Base from 'terra-base';
+import ActionHeader from '../../src/ActionHeader';
+
+const locale = document.getElementsByTagName('html')[0].getAttribute('lang');
+
+const KeepCloseButtonHeader = () => (
+  <Base locale={locale}>
+    <ActionHeader
+      title="Action Header"
+      onClose={() => 1}
+      keepCloseButton
+    />
+  </Base>
+);
+
+export default KeepCloseButtonHeader;

--- a/packages/terra-clinical-action-header/tests/nightwatch/action-header-spec.js
+++ b/packages/terra-clinical-action-header/tests/nightwatch/action-header-spec.js
@@ -40,8 +40,8 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
     const width = screenWidth(browser);
     if (width < browser.globals.breakpoints.medium[0]) {
       browser
-        .assert.elementPresent('[class*="left-buttons"] > button')
-        .assert.attributeContains('[class*="left-buttons"] > button', 'aria-label', 'Back');
+        .assert.elementPresent('[class*="right-buttons"] > button')
+        .assert.attributeContains('[class*="right-buttons"] > button', 'aria-label', 'Close');
     } else {
       browser
         .assert.elementPresent('[class*="right-buttons"] > button')

--- a/packages/terra-clinical-action-header/tests/nightwatch/action-header-spec.js
+++ b/packages/terra-clinical-action-header/tests/nightwatch/action-header-spec.js
@@ -35,6 +35,20 @@ module.exports = resizeTo(['tiny', 'small', 'medium', 'large', 'huge', 'enormous
     }
   },
 
+  'Displays an action header with close button even in small view ports': (browser) => {
+    browser.url(`${browser.launchUrl}/#/tests/action-header-tests/action-header-keep-close-button`);
+    const width = screenWidth(browser);
+    if (width < browser.globals.breakpoints.medium[0]) {
+      browser
+        .assert.elementPresent('[class*="left-buttons"] > button')
+        .assert.attributeContains('[class*="left-buttons"] > button', 'aria-label', 'Back');
+    } else {
+      browser
+        .assert.elementPresent('[class*="right-buttons"] > button')
+        .assert.attributeContains('[class*="right-buttons"] > button', 'aria-label', 'Close');
+    }
+  },
+
   'Displays an action header with maximize button': (browser) => {
     browser.url(`${browser.launchUrl}/#/tests/action-header-tests/action-header-maximize`);
     const width = screenWidth(browser);

--- a/packages/terra-clinical-site/src/examples/action-header/ActionHeader-BackNextPreviousClose.jsx
+++ b/packages/terra-clinical-site/src/examples/action-header/ActionHeader-BackNextPreviousClose.jsx
@@ -11,7 +11,6 @@ const ActionHeaderExample = () => (
       onBack={() => alert('You clicked back!')}
       onNext={() => alert('You clicked next!')}
       onPrevious={() => alert('You clicked previous!')}
-      keepCloseButton
     />
     <br />
   </div>

--- a/packages/terra-clinical-site/src/examples/action-header/ActionHeader-KeepClose.jsx
+++ b/packages/terra-clinical-site/src/examples/action-header/ActionHeader-KeepClose.jsx
@@ -8,9 +8,6 @@ const ActionHeaderExample = () => (
     <ActionHeader
       title="Action Header"
       onClose={() => alert('You clicked close!')}
-      onBack={() => alert('You clicked back!')}
-      onNext={() => alert('You clicked next!')}
-      onPrevious={() => alert('You clicked previous!')}
       keepCloseButton
     />
     <br />

--- a/packages/terra-clinical-site/src/examples/action-header/Index.jsx
+++ b/packages/terra-clinical-site/src/examples/action-header/Index.jsx
@@ -13,6 +13,7 @@ import HeaderSrc from '!raw-loader!terra-clinical-action-header/src/ActionHeader
 import ActionHeaderBackNextPreviousClose from './ActionHeader-BackNextPreviousClose';
 import ActionHeaderExpandClose from './ActionHeader-MaximizeClose';
 import ActionHeaderMinimizeCustomClose from './ActionHeader-MinimizeCustomClose';
+import ActionHeaderKeepClose from './ActionHeader-KeepClose';
 
 const HeaderExamples = () => (
   <div>
@@ -24,6 +25,8 @@ const HeaderExamples = () => (
     <ActionHeaderBackNextPreviousClose />
     <h2>Maximize, Close</h2>
     <ActionHeaderExpandClose />
+    <h2>Close, keepCloseButton</h2>
+    <ActionHeaderKeepClose />
     <h2>Minimize, Custom Content, Children, Close </h2>
     <ActionHeaderMinimizeCustomClose />
   </div>

--- a/packages/terra-clinical-site/src/examples/action-header/Index.jsx
+++ b/packages/terra-clinical-site/src/examples/action-header/Index.jsx
@@ -25,7 +25,7 @@ const HeaderExamples = () => (
     <ActionHeaderBackNextPreviousClose />
     <h2>Maximize, Close</h2>
     <ActionHeaderExpandClose />
-    <h2>Close, keepCloseButton</h2>
+    <h2>Keeps close button in small view port</h2>
     <ActionHeaderKeepClose />
     <h2>Minimize, Custom Content, Children, Close </h2>
     <ActionHeaderMinimizeCustomClose />


### PR DESCRIPTION
### Summary
This gives option to the consumers to opt out of the default close button behavior on small view ports in terra-clinical-action-header. https://github.com/cerner/terra-clinical/blob/terra-clinical-header%401.7.0/packages/terra-clinical-action-header/src/ActionHeader.jsx#L27

### Additional Details
The default behavior is:
"On small viewports a back button will be displayed instead of a close button when a separate onBack callback is not set"

This change adds a new boolean prop `keepCloseButton` (you can suggest a better name) which when set true will disable the default behavior.