### PR TITLE
Disable cache for travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ script:
 branches:
   only:
     - master
-cache:
-  directories:
-    - node_modules
+cache: false
 before_install:
   - docker pull selenium/standalone-chrome:3.8.1-erbium
   - docker run -v /dev/shm:/dev/shm -e TZ=America/Chicago -d -p 4444:4444 selenium/standalone-chrome:3.8.1-erbium


### PR DESCRIPTION
### Summary
Disabling cache in travis-ci to avoid problems seen when using outdated dependancies

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
