### PR TITLE
Add section id attribute on DataGrid headers

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,7 @@ Cerner Corporation
 - Eric Wilson [@eawww]
 - Matt Anderson [@mndrsn]
 - Stephen Esser [@StephenEsser]
+- Jeff Merten [@jeffmerten]
 
 [@dkasper-was-taken]: https://github.com/dkasper-was-taken
 [@jmsv6d]: https://github.com/jmsv6d
@@ -53,3 +54,4 @@ Cerner Corporation
 [@eawww]: https://github.com/eawww
 [@mndrsn]: https://github.com/mndrsn
 [@StephenEsser]: https://github.com/StephenEsser
+[@jeffmerten]: https://github.com/jeffmerten

--- a/packages/terra-clinical-data-grid/CHANGELOG.md
+++ b/packages/terra-clinical-data-grid/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+### Added
+* Added attribute containing id on section headers
+
 2.1.0 - (January 22, 2019)
 ----------
 ### Change

--- a/packages/terra-clinical-data-grid/docs/README.md
+++ b/packages/terra-clinical-data-grid/docs/README.md
@@ -48,6 +48,8 @@ Sections are provided to the DataGrid through the `sections` prop. The order in 
 
 > Note: if `text`, `startAccessory`, `endAccessory`, and `component` are not provided, and if `isCollapsible` is false, no section header will be rendered. However, the `rows` of the section will continue to be rendered.
 
+Section headers will be provided the attribute `data-section-header-id="${sectionId}` for interested consumers.
+
 ### Rows
 
 Rows define the cells rendered within the row as well as the row's selection properties.

--- a/packages/terra-clinical-data-grid/docs/README.md
+++ b/packages/terra-clinical-data-grid/docs/README.md
@@ -48,7 +48,7 @@ Sections are provided to the DataGrid through the `sections` prop. The order in 
 
 > Note: if `text`, `startAccessory`, `endAccessory`, and `component` are not provided, and if `isCollapsible` is false, no section header will be rendered. However, the `rows` of the section will continue to be rendered.
 
-Section headers will be provided the attribute `data-section-header-id="${sectionId}` for interested consumers.
+Section headers will be provided the attribute `data-terra-clinical-data-grid-section-header-id="${sectionId}` for interested consumers.
 
 ### Rows
 

--- a/packages/terra-clinical-data-grid/src/subcomponents/SectionHeader.jsx
+++ b/packages/terra-clinical-data-grid/src/subcomponents/SectionHeader.jsx
@@ -113,7 +113,7 @@ class SectionHeader extends React.Component {
     return (
       <div
         className={cx('section-header')}
-        data-terra-clinical-data-grid-section-header
+        data-section-header
         data-terra-clinical-data-grid-section-header-id={sectionId}
       >
         <div

--- a/packages/terra-clinical-data-grid/src/subcomponents/SectionHeader.jsx
+++ b/packages/terra-clinical-data-grid/src/subcomponents/SectionHeader.jsx
@@ -80,7 +80,7 @@ class SectionHeader extends React.Component {
 
   render() {
     const {
-      text, startAccessory, endAccessory, children, isCollapsible, isCollapsed, selectableRefCallback,
+      sectionId, text, startAccessory, endAccessory, children, isCollapsible, isCollapsed, selectableRefCallback,
     } = this.props;
 
     let content;
@@ -114,6 +114,7 @@ class SectionHeader extends React.Component {
       <div
         className={cx('section-header')}
         data-section-header
+        data-section-header-id={sectionId}
       >
         <div
           role="button"

--- a/packages/terra-clinical-data-grid/src/subcomponents/SectionHeader.jsx
+++ b/packages/terra-clinical-data-grid/src/subcomponents/SectionHeader.jsx
@@ -113,8 +113,8 @@ class SectionHeader extends React.Component {
     return (
       <div
         className={cx('section-header')}
-        data-section-header
-        data-section-header-id={sectionId}
+        data-terra-clinical-data-grid-section-header
+        data-terra-clinical-data-grid-section-header-id={sectionId}
       >
         <div
           role="button"

--- a/packages/terra-clinical-data-grid/tests/jest/subcomponents/__snapshots__/SectionHeader.test.jsx.snap
+++ b/packages/terra-clinical-data-grid/tests/jest/subcomponents/__snapshots__/SectionHeader.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`SectionHeader Snapshot Tests should render a SectionHeader as collapsed 1`] = `
 <div
   className="section-header"
-  data-terra-clinical-data-grid-section-header={true}
+  data-section-header={true}
   data-terra-clinical-data-grid-section-header-id="test-section"
 >
   <div
@@ -53,7 +53,7 @@ exports[`SectionHeader Snapshot Tests should render a SectionHeader as collapsed
 exports[`SectionHeader Snapshot Tests should render a SectionHeader with child content if provided 1`] = `
 <div
   className="section-header"
-  data-terra-clinical-data-grid-section-header={true}
+  data-section-header={true}
   data-terra-clinical-data-grid-section-header-id="test-section"
 >
   <div
@@ -87,7 +87,7 @@ exports[`SectionHeader Snapshot Tests should render a SectionHeader with child c
 exports[`SectionHeader Snapshot Tests should render a SectionHeader with default text/accessory props 1`] = `
 <div
   className="section-header"
-  data-terra-clinical-data-grid-section-header={true}
+  data-section-header={true}
   data-terra-clinical-data-grid-section-header-id="test-section"
 >
   <div
@@ -137,7 +137,7 @@ exports[`SectionHeader Snapshot Tests should render a SectionHeader with default
 exports[`SectionHeader Snapshot Tests should render a SectionHeader with minimal props 1`] = `
 <div
   className="section-header"
-  data-terra-clinical-data-grid-section-header={true}
+  data-section-header={true}
   data-terra-clinical-data-grid-section-header-id="test-section"
 >
   <div

--- a/packages/terra-clinical-data-grid/tests/jest/subcomponents/__snapshots__/SectionHeader.test.jsx.snap
+++ b/packages/terra-clinical-data-grid/tests/jest/subcomponents/__snapshots__/SectionHeader.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`SectionHeader Snapshot Tests should render a SectionHeader as collapsed
 <div
   className="section-header"
   data-section-header={true}
+  data-section-header-id="test-section"
 >
   <div
     className="content selectable"
@@ -53,6 +54,7 @@ exports[`SectionHeader Snapshot Tests should render a SectionHeader with child c
 <div
   className="section-header"
   data-section-header={true}
+  data-section-header-id="test-section"
 >
   <div
     className="content selectable"
@@ -86,6 +88,7 @@ exports[`SectionHeader Snapshot Tests should render a SectionHeader with default
 <div
   className="section-header"
   data-section-header={true}
+  data-section-header-id="test-section"
 >
   <div
     className="content selectable"
@@ -135,6 +138,7 @@ exports[`SectionHeader Snapshot Tests should render a SectionHeader with minimal
 <div
   className="section-header"
   data-section-header={true}
+  data-section-header-id="test-section"
 >
   <div
     className="content"

--- a/packages/terra-clinical-data-grid/tests/jest/subcomponents/__snapshots__/SectionHeader.test.jsx.snap
+++ b/packages/terra-clinical-data-grid/tests/jest/subcomponents/__snapshots__/SectionHeader.test.jsx.snap
@@ -3,8 +3,8 @@
 exports[`SectionHeader Snapshot Tests should render a SectionHeader as collapsed 1`] = `
 <div
   className="section-header"
-  data-section-header={true}
-  data-section-header-id="test-section"
+  data-terra-clinical-data-grid-section-header={true}
+  data-terra-clinical-data-grid-section-header-id="test-section"
 >
   <div
     className="content selectable"
@@ -53,8 +53,8 @@ exports[`SectionHeader Snapshot Tests should render a SectionHeader as collapsed
 exports[`SectionHeader Snapshot Tests should render a SectionHeader with child content if provided 1`] = `
 <div
   className="section-header"
-  data-section-header={true}
-  data-section-header-id="test-section"
+  data-terra-clinical-data-grid-section-header={true}
+  data-terra-clinical-data-grid-section-header-id="test-section"
 >
   <div
     className="content selectable"
@@ -87,8 +87,8 @@ exports[`SectionHeader Snapshot Tests should render a SectionHeader with child c
 exports[`SectionHeader Snapshot Tests should render a SectionHeader with default text/accessory props 1`] = `
 <div
   className="section-header"
-  data-section-header={true}
-  data-section-header-id="test-section"
+  data-terra-clinical-data-grid-section-header={true}
+  data-terra-clinical-data-grid-section-header-id="test-section"
 >
   <div
     className="content selectable"
@@ -137,8 +137,8 @@ exports[`SectionHeader Snapshot Tests should render a SectionHeader with default
 exports[`SectionHeader Snapshot Tests should render a SectionHeader with minimal props 1`] = `
 <div
   className="section-header"
-  data-section-header={true}
-  data-section-header-id="test-section"
+  data-terra-clinical-data-grid-section-header={true}
+  data-terra-clinical-data-grid-section-header-id="test-section"
 >
   <div
     className="content"


### PR DESCRIPTION
### Summary
Adds an attribute on the section header of terra-clinical-data-grid that is unique to the section id.

### Additional Details
For one of our use cases, we'd like to scroll the header into view on component mount. This change lets us properly do this.

### Related issue
https://github.com/cerner/terra-clinical/issues/457