### PR TITLE
[terra-clinical-data-grid] Updating unmount implementation to cancel any pending animation frames

### DIFF
--- a/packages/terra-clinical-data-grid/CHANGELOG.md
+++ b/packages/terra-clinical-data-grid/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+### Changed
+* Updated unmount implementation to cancel any pending animation frames
+
 2.2.0 - (February 5, 2019)
 ----------
 ### Added

--- a/packages/terra-clinical-data-grid/src/DataGrid.jsx
+++ b/packages/terra-clinical-data-grid/src/DataGrid.jsx
@@ -274,6 +274,13 @@ class DataGrid extends React.Component {
 
     document.removeEventListener('keydown', this.handleKeyDown);
     document.removeEventListener('keyup', this.handleKeyUp);
+
+    /**
+     * If the component is unmounting, we need to cancel any post-render manipulation before the DOM elements
+     * go out of scope.
+     */
+    cancelAnimationFrame(this.postRenderUpdateAnimationFrame);
+    cancelAnimationFrame(this.scrollSyncAnimationFrame);
   }
 
   /**
@@ -463,7 +470,12 @@ class DataGrid extends React.Component {
      */
     this.accessibilityStack = dataGridUtils.generateAccessibleContentIndex(this.props, this.headerCellRefs, this.sectionRefs, this.cellRefs);
 
-    requestAnimationFrame(() => {
+    /**
+     * The previous animation frame is canceled if it is still pending.
+     */
+    cancelAnimationFrame(this.postRenderUpdateAnimationFrame);
+
+    this.postRenderUpdateAnimationFrame = requestAnimationFrame(() => {
       /**
        * The SectionHeader widths must be updated after rendering to match the rendered DataGrid's width.
        */
@@ -601,9 +613,7 @@ class DataGrid extends React.Component {
 
     this.synchronizeScrollTimeout = setTimeout(this.resetHeaderScrollEventMarkers, 100);
 
-    if (this.scrollSyncAnimationFrame) {
-      cancelAnimationFrame(this.scrollSyncAnimationFrame);
-    }
+    cancelAnimationFrame(this.scrollSyncAnimationFrame);
 
     this.scrollSyncAnimationFrame = requestAnimationFrame(() => {
       this.horizontalOverflowContainerRef.scrollLeft = this.headerOverflowContainerRef.scrollLeft;
@@ -625,9 +635,7 @@ class DataGrid extends React.Component {
 
     this.synchronizeScrollTimeout = setTimeout(this.resetContentScrollEventMarkers, 100);
 
-    if (this.scrollSyncAnimationFrame) {
-      cancelAnimationFrame(this.scrollSyncAnimationFrame);
-    }
+    cancelAnimationFrame(this.scrollSyncAnimationFrame);
 
     this.scrollSyncAnimationFrame = requestAnimationFrame(() => {
       this.headerOverflowContainerRef.scrollLeft = this.horizontalOverflowContainerRef.scrollLeft;
@@ -660,9 +668,7 @@ class DataGrid extends React.Component {
     const positionRatio = finalPosition / scrollArea;
     const maxScrollLeft = this.horizontalOverflowContainerRef.scrollWidth - this.horizontalOverflowContainerRef.clientWidth;
 
-    if (this.scrollSyncAnimationFrame) {
-      cancelAnimationFrame(this.scrollSyncAnimationFrame);
-    }
+    cancelAnimationFrame(this.scrollSyncAnimationFrame);
 
     this.scrollSyncAnimationFrame = requestAnimationFrame(() => {
       this.scrollbarRef.style.transform = `translateX(${this.scrollbarPosition}px)`;


### PR DESCRIPTION
### Summary
A consumer of the DataGrid ran into a workflow that both updated a DataGrid and unmounted the same DataGrid very quickly. This was causing the animation frame logic triggered by the update to execute _after_ the component unmounted and after all the elements have gone out of scope.

To prevent this from happening, we're going to cancel any pending animation frames during the DataGrid's componentWillUnmount lifecycle implementation. I'm canceling the animation frame logic that synchronizes the horizontal scroll positioning for good measure.

I also cleaned up the unnecessary checks around the presence of those animation frame ids before canceling them. Calling cancelAnimationFrame with undefined is supported, and the animation frame ids will persist even after they have executed, so the presence checks aren't really doing much good.
