### PR TITLE
Update badges to point to travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
       deploy:
         provider: pages
         skip_cleanup: true
-        github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+        github_token: $GITHUB_TOKEN # Set in travis-ci.com dashboard
         local_dir: build
         on:
           branch: master

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Cerner OSS](https://badgen.net/badge/Cerner/OSS/blue)](http://engineering.cerner.com/2014/01/cerner-and-open-source/)
 [![License](https://badgen.net/github/license/cerner/terra-clinical)](https://github.com/cerner/terra-clinical/blob/master/LICENSE)
-[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.org/cerner/terra-clinical)
+[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.com/cerner/terra-clinical)
 [![devDependencies status](https://badgen.net/david/dev/cerner/terra-clinical)](https://david-dm.org/cerner/terra-clinical?type=dev)
 [![lerna](https://badgen.net/badge/maintained%20with/lerna/cc00ff)](https://lernajs.io/)
 

--- a/packages/terra-clinical-application/README.md
+++ b/packages/terra-clinical-application/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-clinical-application)](https://www.npmjs.org/package/terra-clinical-application)
-[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.org/cerner/terra-clinical)
+[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.com/cerner/terra-clinical)
 
 The Application is a wrapper component around `terra-base` that provides clinical application-specific properties.
 

--- a/packages/terra-clinical-data-grid/README.md
+++ b/packages/terra-clinical-data-grid/README.md
@@ -3,7 +3,7 @@
 The DataGrid is an organizational component that renders a collection of data in a grid-like format.
 
 [![NPM version](http://img.shields.io/npm/v/terra-clinical-data-grid.svg)](https://www.npmjs.org/package/terra-clinical-data-grid)
-[![Build Status](https://travis-ci.org/cerner/terra-clinical.svg?branch=master)](https://travis-ci.org/cerner/terra-clinical)
+[![Build Status](https://travis-ci.com/cerner/terra-clinical.svg?branch=master)](https://travis-ci.com/cerner/terra-clinical)
 
 - [Getting Started](#getting-started)
 - [Documentation](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-data-grid/docs)

--- a/packages/terra-clinical-detail-view/README.md
+++ b/packages/terra-clinical-detail-view/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-clinical-detail-view)](https://www.npmjs.org/package/terra-clinical-detail-view)
-[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.org/cerner/terra-clinical)
+[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.com/cerner/terra-clinical)
 
 Detail Views allows you to create a view with text at different levels of importance. A detail view can contain a title, subtitles, a graph, a footer and a list of elements that can display information at a more detailed level.
 

--- a/packages/terra-clinical-header/README.md
+++ b/packages/terra-clinical-header/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-clinical-header)](https://www.npmjs.org/package/terra-clinical-header)
-[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.org/cerner/terra-clinical)
+[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.com/cerner/terra-clinical)
 
 A Header component that allows elements to be placed on the left and right ends of the header with a left aligned title in the center.
 

--- a/packages/terra-clinical-item-collection/README.md
+++ b/packages/terra-clinical-item-collection/README.md
@@ -1,7 +1,7 @@
 # Terra Clinical Item Collection
 
 [![NPM version](https://badgen.net/npm/v/terra-clinical-item-collection)](https://www.npmjs.org/package/terra-clinical-item-collection)
-[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://travis-ci.com/cerner/terra-core.svg?branch=master)](https://travis-ci.com/cerner/terra-core)
 
 An Item Collection is a wrapper component designed to display data as either a table or list of items dependent on the relative container size. Initially data is displayed in a tabular format that flexes the rendered component, but as the container is resized and the indicated breakpoint is hit, the display changes to show the data as a list of items. The terra-table and terra-clinical-item react components will be utilized for displaying the data in these two ways.
 

--- a/packages/terra-clinical-item-display/README.md
+++ b/packages/terra-clinical-item-display/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-clinical-item-display)](https://www.npmjs.org/package/terra-clinical-item-display)
-[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.org/cerner/terra-clinical)
+[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.com/cerner/terra-clinical)
 
 The Item Display component creates an display for text and an optional graphic. The Comment subcomponent creates a display for text with a comment icon.
 

--- a/packages/terra-clinical-item-view/README.md
+++ b/packages/terra-clinical-item-view/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-clinical-item-view)](https://www.npmjs.org/package/terra-clinical-item-view)
-[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.org/cerner/terra-clinical)
+[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.com/cerner/terra-clinical)
 
 The Item View component allows displays to be organized into rows and column and themed, while providing means to add accessory elements and a comment.
 

--- a/packages/terra-clinical-label-value-view/README.md
+++ b/packages/terra-clinical-label-value-view/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-clinical-label-value-view)](https://www.npmjs.org/package/terra-clinical-label-value-view)
-[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.org/cerner/terra-clinical)
+[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.com/cerner/terra-clinical)
 
 The label value view component displays a label and the associated value or list
 of values underneath the label.

--- a/packages/terra-clinical-onset-picker/README.md
+++ b/packages/terra-clinical-onset-picker/README.md
@@ -2,7 +2,7 @@
 
 
 [![NPM version](https://badgen.net/npm/v/terra-clinical-onset-picker)](https://www.npmjs.org/package/terra-clinical-onset-picker)
-[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.org/cerner/terra-clinical)
+[![Build Status](https://badgen.net/travis/cerner/terra-clinical)](https://travis-ci.com/cerner/terra-clinical)
 
 The terra-clinical-onset-picker component provides users a way to enter or select an approximate date for onset scenarios.
 


### PR DESCRIPTION
### Summary
Updates travis build status badges to point to `travis-ci.com` instead of `travis-ci.org`

Closes #508 