### PR TITLE
[terra-clinical-item-view] Updated misleading documentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,6 +33,7 @@ Cerner Corporation
 - Supreeth MR [@supreethmr]
 - Naveen Kumar Ramamurthy [@nramamurth]
 - Lokesh P [@lokesh-0813]
+- Pranav Agarwal [@pranav300]
 
 Community
 
@@ -72,3 +73,4 @@ Community
 [@nramamurth]: https://github.com/nramamurth
 [@PayalSawant]: https://github.com/PayalSawant
 [@lokesh-0813]: https://github.com/lokesh-0813
+[@pranav300]: https://github.com/pranav300

--- a/packages/terra-clinical-item-view/CHANGELOG.md
+++ b/packages/terra-clinical-item-view/CHANGELOG.md
@@ -3,6 +3,9 @@ ChangeLog
 
 Unreleased
 ----------
+###Updated
+* Updated displays documentation
+
 ### Changed
 * Update tests for terra-toolkit v5 and terra-dev-site v5 changes
 

--- a/packages/terra-clinical-item-view/src/ItemView.jsx
+++ b/packages/terra-clinical-item-view/src/ItemView.jsx
@@ -36,7 +36,7 @@ const propTypes = {
    */
   endAccessory: PropTypes.node,
   /**
-   * An array of react display elements to be presented.
+   * An array of  terra-clinical-item-display's to be presented.
    */
   displays: PropTypes.arrayOf(PropTypes.element),
   /**

--- a/packages/terra-clinical-item-view/src/ItemView.jsx
+++ b/packages/terra-clinical-item-view/src/ItemView.jsx
@@ -36,7 +36,7 @@ const propTypes = {
    */
   endAccessory: PropTypes.node,
   /**
-   * An array of  terra-clinical-item-display's to be presented.
+   * An array of terra-clinical-item-display's to be presented.
    */
   displays: PropTypes.arrayOf(PropTypes.element),
   /**


### PR DESCRIPTION
### Summary
Updated terra-clinical-item-view misleading `children` documentation.
Resolves #513
