### PR TITLE
Make tests consistent

### DIFF
--- a/packages/terra-clinical-data-grid/CHANGELOG.md
+++ b/packages/terra-clinical-data-grid/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Added
 * Added enumeration for valid column sort indicator values
 
+### Fixed
+* Fix issue with test consistency
+
 2.6.0 - (June 11, 2019)
 ----------
 ### Changed

--- a/packages/terra-clinical-data-grid/tests/wdio/data-grid-spec.js
+++ b/packages/terra-clinical-data-grid/tests/wdio/data-grid-spec.js
@@ -176,7 +176,7 @@ Terra.describeViewports('DataGrid', ['medium', 'huge'], () => {
     before(() => {
       browser.url('/#/raw/tests/terra-clinical-data-grid/clinical-data-grid/selectable-data-grid');
       browser.click('#selections-example-Pinned-Row-Row-0-Section-section_0 > *:first-child');
-      browser.moveTo(0, 0);
+      browser.moveTo(null, 0, 0);
     });
 
     Terra.it.validatesElement({ selector: '#selectable-data-grid' });

--- a/packages/terra-clinical-data-grid/tests/wdio/data-grid-spec.js
+++ b/packages/terra-clinical-data-grid/tests/wdio/data-grid-spec.js
@@ -176,6 +176,7 @@ Terra.describeViewports('DataGrid', ['medium', 'huge'], () => {
     before(() => {
       browser.url('/#/raw/tests/terra-clinical-data-grid/clinical-data-grid/selectable-data-grid');
       browser.click('#selections-example-Pinned-Row-Row-0-Section-section_0 > *:first-child');
+      browser.moveTo(0, 0);
     });
 
     Terra.it.validatesElement({ selector: '#selectable-data-grid' });


### PR DESCRIPTION
### Summary
We are having an issue with consistency in our tests with one of the internal themes where it sometimes has a hover effect.  This will move the cursor out of the way to ensure that doesn't happen.