### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "browserslist-config-terra": "^1.0.0",
     "check-installed-dependencies": "^1.0.0",
     "core-js": "^3.1.3",
-    "danger": "^7.0.0",
+    "danger": "^9.1.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.2.2",


### PR DESCRIPTION
Danger seems to have resolved the transitive dependency issue we were running into in 9.0.1.
Updating to 9.1.0.