### PR TITLE
Add eslint overrides to allow us to clean up eslint comments in doc and test files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,29 @@
     "extends browserslist-config-terra"
   ],
   "eslintConfig": {
-    "extends": "terra"
+    "extends": "terra",
+    "overrides": [
+      {
+        "files": [
+          "**/*/terra-dev-site/**/*.jsx"
+        ],
+        "rules": {
+          "import/no-extraneous-dependencies": "off",
+          "import/no-unresolved": "off",
+          "import/extensions": "off"
+        }
+      },
+      {
+        "files": [
+          "*.doc.jsx"
+        ],
+        "rules": {
+          "import/no-webpack-loader-syntax": "off",
+          "import/first": "off",
+          "import/no-duplicates": "off"
+        }
+      }
+    ]
   },
   "stylelint": {
     "extends": "stylelint-config-terra",

--- a/packages/terra-clinical-data-grid/CHANGELOG.md
+++ b/packages/terra-clinical-data-grid/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 ### Changed
 * Replaced Object.assign syntax with Object spread syntax
 * Add comments for ESlint 6
+* Cleaned up imports in examples and test files
 
 2.9.0 - (August 14, 2019)
 ----------

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/Datagrid.1.doc.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/Datagrid.1.doc.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import ExampleTemplate from 'terra-doc-template/lib/ExampleTemplate';
-
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 import Datagrid from './Datagrid';
 import DatagridSrc from '!raw-loader!../../../../../src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/Datagrid';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DatagridExample = () => (
   <ExampleTemplate

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/Datagrid.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/Datagrid.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 import classNames from 'classnames/bind';
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithColumnResizing.5.doc.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithColumnResizing.5.doc.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import ExampleTemplate from 'terra-doc-template/lib/ExampleTemplate';
-
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 import DatagridWithColumnResizing from './DatagridWithColumnResizing';
 import DatagridWithColumnResizingSrc from '!raw-loader!../../../../../src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithColumnResizing';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DatagridWithColumnResizingExample = () => (
   <ExampleTemplate

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithColumnResizing.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithColumnResizing.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 import classNames from 'classnames/bind';
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithCustomContent.7.doc.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithCustomContent.7.doc.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import ExampleTemplate from 'terra-doc-template/lib/ExampleTemplate';
-
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 import DatagridWithCustomContent from './DatagridWithCustomContent';
 import DatagridWithCustomContentSrc from '!raw-loader!../../../../../src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithCustomContent';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DatagridWithColumnResizingExample = () => (
   <ExampleTemplate

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithCustomContent.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithCustomContent.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 import ItemView from 'terra-clinical-item-view';
 import classNames from 'classnames/bind';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithNoPinnedColumns.2.doc.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithNoPinnedColumns.2.doc.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import ExampleTemplate from 'terra-doc-template/lib/ExampleTemplate';
-
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 import DatagridWithNoPinnedColumns from './DatagridWithNoPinnedColumns';
 import DatagridWithNoPinnedColumnsSrc from '!raw-loader!../../../../../src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithNoPinnedColumns';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DatagridWithNoPinnedColumnsExample = () => (
   <ExampleTemplate

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithNoPinnedColumns.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithNoPinnedColumns.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 import classNames from 'classnames/bind';
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithPaging.6.doc.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithPaging.6.doc.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import ExampleTemplate from 'terra-doc-template/lib/ExampleTemplate';
-
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 import DatagridWithPaging from './DatagridWithPaging';
 import DatagridWithPagingSrc from '!raw-loader!../../../../../src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithPaging';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DatagridWithPagingExample = () => (
   <ExampleTemplate

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithPaging.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithPaging.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 import LoadingOverlay from 'terra-overlay/lib/LoadingOverlay';
 import classNames from 'classnames/bind';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithSelections.4.doc.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithSelections.4.doc.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import ExampleTemplate from 'terra-doc-template/lib/ExampleTemplate';
-
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 import DatagridWithSelections from './DatagridWithSelections';
 import DatagridWithSelectionsSrc from '!raw-loader!../../../../../src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithSelections';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DatagridWithSelectionsExample = () => (
   <ExampleTemplate

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithSelections.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithSelections.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 import classNames from 'classnames/bind';
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithSubsections.3.doc.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithSubsections.3.doc.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import ExampleTemplate from 'terra-doc-template/lib/ExampleTemplate';
-
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 import DatagridWithSubsections from './DatagridWithSubsections';
 import DatagridWithSubsectionsSrc from '!raw-loader!../../../../../src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithSubsections';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DatagridWithSubsectionsExample = () => (
   <ExampleTemplate

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithSubsections.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithSubsections.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-
 import Button from 'terra-button';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 import classNames from 'classnames/bind';
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithoutFill.8.doc.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithoutFill.8.doc.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import ExampleTemplate from 'terra-doc-template/lib/ExampleTemplate';
-
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 import DatagridWithoutFill from './DatagridWithoutFill';
 import DatagridWithoutFillSrc from '!raw-loader!../../../../../src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/Datagrid';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DatagridWithoutFillExample = () => (
   <ExampleTemplate

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithoutFill.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/DatagridExamples.2/DatagridWithoutFill.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/clinicalDataGrid.1.doc.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/clinicalDataGrid.1.doc.jsx
@@ -2,12 +2,8 @@ import React from 'react';
 import DocTemplate from 'terra-doc-template';
 import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
-
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 // Component Source
 import DataGridSrc from '!raw-loader!../../../../src/DataGrid';
-
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DocPage = () => (
   <DocTemplate

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/CustomHeightDataGrid.test.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/CustomHeightDataGrid.test.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
-
 import ContentCellLayout from './ContentCellLayout';
 
 const pinnedColumns = [

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/NoFillDataGrid.test.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/NoFillDataGrid.test.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
-
 import ContentCellLayout from './ContentCellLayout';
 
 const pinnedColumns = [

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/NoOverflowColumnDataGrid.test.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/NoOverflowColumnDataGrid.test.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/NoOverflowDataGrid.test.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/NoOverflowDataGrid.test.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/NoPinnedColumnDataGrid.test.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/NoPinnedColumnDataGrid.test.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/PagedContentDataGrid.test.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/PagedContentDataGrid.test.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/SelectableDataGrid.test.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/SelectableDataGrid.test.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/StandardDataGrid.test.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/StandardDataGrid.test.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/SubsectionDataGrid.test.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/test/clinical-data-grid/SubsectionDataGrid.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import Button from 'terra-button';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
 import DataGrid from 'terra-clinical-data-grid';
 
 import ContentCellLayout from './ContentCellLayout';

--- a/packages/terra-clinical-detail-view/CHANGELOG.md
+++ b/packages/terra-clinical-detail-view/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 ### Changed
 * Replaced Object.assign syntax with Object spread syntax
 * Add comments for ESlint 6
+* Cleaned up imports in examples and test files
 
 3.7.0 - (August 14, 2019)
 ----------

--- a/packages/terra-clinical-detail-view/src/terra-dev-site/doc/clinical-detail-view/clinicalDetailView.1.doc.jsx
+++ b/packages/terra-clinical-detail-view/src/terra-dev-site/doc/clinical-detail-view/clinicalDetailView.1.doc.jsx
@@ -3,7 +3,6 @@ import DocTemplate from 'terra-doc-template';
 import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 // Component Source
 import DetailViewSrc from '!raw-loader!../../../../src/DetailView';
 import DetailListSrc from '!raw-loader!../../../../src/DetailList';
@@ -16,7 +15,6 @@ import DetailViewNoDivider from '../example/DetailViewNoDivider';
 import DetailViewNoDividerSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/DetailViewNoDivider';
 import DetailViewDividedSmallerTitles from '../example/DetailViewDividedSmallerTitles';
 import DetailViewDividedSmallerTitlesSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/DetailViewDividedSmallerTitles';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DocPage = () => (
   <DocTemplate

--- a/packages/terra-clinical-detail-view/src/terra-dev-site/doc/example/DetailViewDivided.jsx
+++ b/packages/terra-clinical-detail-view/src/terra-dev-site/doc/example/DetailViewDivided.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import LabelValueView from 'terra-clinical-label-value-view';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import DetailView from 'terra-clinical-detail-view/lib/DetailView';
+import DetailView from 'terra-clinical-detail-view';
 import classNames from 'classnames/bind';
 import styles from './DetailViewDivided.module.scss';
 

--- a/packages/terra-clinical-detail-view/src/terra-dev-site/doc/example/DetailViewDividedSmallerTitles.jsx
+++ b/packages/terra-clinical-detail-view/src/terra-dev-site/doc/example/DetailViewDividedSmallerTitles.jsx
@@ -6,8 +6,7 @@ import IconPharmacyReview from 'terra-icon/lib/icon/IconPharmacyReview';
 import IconPharmacyReject from 'terra-icon/lib/icon/IconPharmacyReject';
 import IconGlasses from 'terra-icon/lib/icon/IconGlasses';
 import classNames from 'classnames/bind';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import DetailView from 'terra-clinical-detail-view/lib/DetailView';
+import DetailView from 'terra-clinical-detail-view';
 import styles from './DetailViewDivided.module.scss';
 
 const cx = classNames.bind(styles);

--- a/packages/terra-clinical-detail-view/src/terra-dev-site/doc/example/DetailViewNoDivider.jsx
+++ b/packages/terra-clinical-detail-view/src/terra-dev-site/doc/example/DetailViewNoDivider.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import LabelValueView from 'terra-clinical-label-value-view';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import DetailView from 'terra-clinical-detail-view/lib/DetailView';
+import DetailView from 'terra-clinical-detail-view';
 import classNames from 'classnames/bind';
 import styles from './DetailViewDivided.module.scss';
 

--- a/packages/terra-clinical-header/CHANGELOG.md
+++ b/packages/terra-clinical-header/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Add comments for ESlint 6
+* Cleaned up imports in examples and test files
 
 3.7.0 - (August 14, 2019)
 ----------

--- a/packages/terra-clinical-header/src/terra-dev-site/doc/clinical-header/clinicalHeader.1.doc.jsx
+++ b/packages/terra-clinical-header/src/terra-dev-site/doc/clinical-header/clinicalHeader.1.doc.jsx
@@ -3,7 +3,6 @@ import DocTemplate from 'terra-doc-template';
 import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 // Component Source
 import HeaderSrc from '!raw-loader!../../../../src/Header';
 
@@ -18,7 +17,6 @@ import HeaderLongTextWithContent from '../example/HeaderLongTextWithContent';
 import HeaderLongTextWithContentSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/HeaderLongTextWithContent';
 import Subheader from '../example/Subheader';
 import SubheaderSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/Subheader';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DocPage = () => (
   <DocTemplate

--- a/packages/terra-clinical-header/src/terra-dev-site/doc/example/ContentHeader.jsx
+++ b/packages/terra-clinical-header/src/terra-dev-site/doc/example/ContentHeader.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Button from 'terra-button';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import Header from 'terra-clinical-header/lib/Header';
+import Header from 'terra-clinical-header';
 import classNames from 'classnames/bind';
 import styles from './ContentHeader.module.scss';
 

--- a/packages/terra-clinical-header/src/terra-dev-site/doc/example/HeaderLongText.jsx
+++ b/packages/terra-clinical-header/src/terra-dev-site/doc/example/HeaderLongText.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import Header from 'terra-clinical-header/lib/Header';
+import Header from 'terra-clinical-header';
 
 const LongTextWithButtons = () => (
   <div>

--- a/packages/terra-clinical-header/src/terra-dev-site/doc/example/HeaderLongTextWithContent.jsx
+++ b/packages/terra-clinical-header/src/terra-dev-site/doc/example/HeaderLongTextWithContent.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Button from 'terra-button';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import Header from 'terra-clinical-header/lib/Header';
+import Header from 'terra-clinical-header';
 import classNames from 'classnames/bind';
 import styles from './ContentHeader.module.scss';
 

--- a/packages/terra-clinical-header/src/terra-dev-site/doc/example/Subheader.jsx
+++ b/packages/terra-clinical-header/src/terra-dev-site/doc/example/Subheader.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Button from 'terra-button';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import Header from 'terra-clinical-header/lib/Header';
+import Header from 'terra-clinical-header';
 import classNames from 'classnames/bind';
 import styles from './ContentHeader.module.scss';
 

--- a/packages/terra-clinical-header/src/terra-dev-site/doc/example/TitleHeader.jsx
+++ b/packages/terra-clinical-header/src/terra-dev-site/doc/example/TitleHeader.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import Header from 'terra-clinical-header/lib/Header';
+import Header from 'terra-clinical-header';
 
 const TitleHeader = () => (
   <Header title="Default Header" />

--- a/packages/terra-clinical-item-collection/CHANGELOG.md
+++ b/packages/terra-clinical-item-collection/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Replaced Object.assign syntax with Object spread syntax
+* Cleaned up imports in examples and test files
 
 4.6.0 - (August 14, 2019)
 ----------

--- a/packages/terra-clinical-item-collection/src/terra-dev-site/doc/clinical-item-collection/clinicalItemCollection.1.doc.jsx
+++ b/packages/terra-clinical-item-collection/src/terra-dev-site/doc/clinical-item-collection/clinicalItemCollection.1.doc.jsx
@@ -3,7 +3,6 @@ import DocTemplate from 'terra-doc-template';
 import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 // Component Source
 import ItemCollectionSrc from '!raw-loader!../../../../src/ItemCollection';
 import ItemSrc from '!raw-loader!../../../../src/Item';
@@ -11,7 +10,6 @@ import ItemSrc from '!raw-loader!../../../../src/Item';
 // Example Files
 import ItemCollectionExample from '../example/ItemCollectionExample';
 import ItemCollectionExampleSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/ItemCollectionExample';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DocPage = () => (
   <DocTemplate

--- a/packages/terra-clinical-item-collection/src/terra-dev-site/doc/example/ItemCollectionExample.jsx
+++ b/packages/terra-clinical-item-collection/src/terra-dev-site/doc/example/ItemCollectionExample.jsx
@@ -4,8 +4,7 @@ import IconAttachment from 'terra-icon/lib/icon/IconAttachment';
 import IconPerson from 'terra-icon/lib/icon/IconPerson';
 import IconAlert from 'terra-icon/lib/icon/IconAlert';
 import IconInformation from 'terra-icon/lib/icon/IconInformation';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemCollection from 'terra-clinical-item-collection/lib/ItemCollection';
+import ItemCollection from 'terra-clinical-item-collection';
 
 const display1 = <ItemCollection.Display icon={<IconPerson />} text="Asif Khan" />;
 const display2 = <ItemCollection.Display text="Care Position: Primary" />;

--- a/packages/terra-clinical-item-display/CHANGELOG.md
+++ b/packages/terra-clinical-item-display/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Add comments for ESlint 6
+* Cleaned up imports in examples and test files
 
 3.6.0 - (August 14, 2019)
 ----------

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.jsx
@@ -3,7 +3,6 @@ import DocTemplate from 'terra-doc-template';
 import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 // Component Source
 import ItemDisplaySrc from '!raw-loader!../../../../src/ItemDisplay';
 import CommentSrc from '!raw-loader!../../../../src/ItemComment';

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/DefaultComment.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/DefaultComment.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemDisplay from 'terra-clinical-item-display/lib/ItemDisplay';
+import ItemDisplay from 'terra-clinical-item-display';
 
 const component = () => (
   <span>

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/Icon.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/Icon.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import IconGlasses from 'terra-icon/lib/icon/IconGlasses';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemDisplay from 'terra-clinical-item-display/lib/ItemDisplay';
+import ItemDisplay from 'terra-clinical-item-display';
 
 const component = () => (<ItemDisplay icon={<IconGlasses />} />);
 

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/IconText.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/IconText.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import IconGlasses from 'terra-icon/lib/icon/IconGlasses';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemDisplay from 'terra-clinical-item-display/lib/ItemDisplay';
+import ItemDisplay from 'terra-clinical-item-display';
 
 const sampleText = 'Mr. James is currently receiving outpatient treatment. He has been diagnosed with an Axis I diagnosis of Psychosis NOS, ruled out Schizoaffective Disorder and Post Traumatic Stress Disorder, and is being treated with Haldol 5mg and Cogentin 1mg. ';
 

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TextStyles.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TextStyles.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemDisplay from 'terra-clinical-item-display/lib/ItemDisplay';
+import ItemDisplay from 'terra-clinical-item-display';
 
 const component = () => (
   <React.Fragment>

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TextStylesDisabled.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TextStylesDisabled.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemDisplay from 'terra-clinical-item-display/lib/ItemDisplay';
+import ItemDisplay from 'terra-clinical-item-display';
 
 const component = () => (
   <React.Fragment>

--- a/packages/terra-clinical-item-view/CHANGELOG.md
+++ b/packages/terra-clinical-item-view/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Add comments for ESlint 6
+* Cleaned up imports in examples and test files
 
 3.6.0 - (August 14, 2019)
 ----------

--- a/packages/terra-clinical-item-view/src/terra-dev-site/doc/clinical-item-view/clinicalItemView.1.doc.jsx
+++ b/packages/terra-clinical-item-view/src/terra-dev-site/doc/clinical-item-view/clinicalItemView.1.doc.jsx
@@ -5,7 +5,6 @@ import ReadMe from '../../../../docs/README.md';
 import ItemViewTwoColumnDocs from '../../../../docs/item-view-two-column.md';
 import { name } from '../../../../package.json';
 
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 // Component Source
 import ItemViewSrc from '!raw-loader!../../../../src/ItemView.jsx';
 
@@ -22,7 +21,6 @@ import ItemViewAll from '../example/ItemViewAll';
 import ItemViewAllSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/ItemViewAll';
 import ItemViewAllTopAligned from '../example/ItemViewAllTopAligned';
 import ItemViewAllTopAlignedSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/ItemViewAllTopAligned';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DocPage = () => (
   <DocTemplate

--- a/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewAll.jsx
+++ b/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewAll.jsx
@@ -3,9 +3,7 @@ import IconPerson from 'terra-icon/lib/icon/IconPerson';
 import IconAlert from 'terra-icon/lib/icon/IconAlert';
 import IconInformation from 'terra-icon/lib/icon/IconInformation';
 import IconBedRequested from 'terra-icon/lib/icon/IconBedRequested';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemView from 'terra-clinical-item-view/lib/ItemView';
+import ItemView from 'terra-clinical-item-view';
 
 const display1 = <ItemView.Display icon={<IconPerson />} iconAlignment="inline" text="Asif Khan" />;
 const display2 = <ItemView.Display icon={<IconBedRequested />} iconAlignment="inline" text="Pending Admit: Bed Requested" />;

--- a/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewAllTopAligned.jsx
+++ b/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewAllTopAligned.jsx
@@ -3,10 +3,7 @@ import IconPerson from 'terra-icon/lib/icon/IconPerson';
 import IconAlert from 'terra-icon/lib/icon/IconAlert';
 import IconInformation from 'terra-icon/lib/icon/IconInformation';
 import IconBedRequested from 'terra-icon/lib/icon/IconBedRequested';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemView from 'terra-clinical-item-view/lib/ItemView';
-
+import ItemView from 'terra-clinical-item-view';
 
 const display1 = <ItemView.Display icon={<IconPerson />} iconAlignment="inline" text="Asif Khan" />;
 const display2 = <ItemView.Display icon={<IconBedRequested />} iconAlignment="inline" text="Pending Admit: Bed Requested" />;

--- a/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewComment.jsx
+++ b/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewComment.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import IconPerson from 'terra-icon/lib/icon/IconPerson';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemView from 'terra-clinical-item-view/lib/ItemView';
-
+import ItemView from 'terra-clinical-item-view';
 
 const display1 = <ItemView.Display icon={<IconPerson />} iconAlignment="inline" text="Asif Khan" />;
 const display2 = <ItemView.Display text="Care Position: Primary" />;

--- a/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewStandard.jsx
+++ b/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewStandard.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import IconPerson from 'terra-icon/lib/icon/IconPerson';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemView from 'terra-clinical-item-view/lib/ItemView';
-
+import ItemView from 'terra-clinical-item-view';
 
 const display1 = <ItemView.Display icon={<IconPerson />} iconAlignment="inline" text="Asif Khan" />;
 const display2 = <ItemView.Display text="Care Position: Primary" />;

--- a/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewTwoColumn.jsx
+++ b/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewTwoColumn.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import IconBriefcase from 'terra-icon/lib/icon/IconBriefcase';
 import IconPerson from 'terra-icon/lib/icon/IconPerson';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemView from 'terra-clinical-item-view/lib/ItemView';
-
+import ItemView from 'terra-clinical-item-view';
 
 const display1 = <ItemView.Display icon={<IconPerson />} iconAlignment="inline" text="Asif Khan" />;
 const display2 = <ItemView.Display icon={<IconBriefcase />} iconAlignment="inline" text="Care Position: Primary" />;

--- a/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewTwoColumnStart.jsx
+++ b/packages/terra-clinical-item-view/src/terra-dev-site/doc/example/ItemViewTwoColumnStart.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import IconPerson from 'terra-icon/lib/icon/IconPerson';
-
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import ItemView from 'terra-clinical-item-view/lib/ItemView';
-
+import ItemView from 'terra-clinical-item-view';
 
 const display1 = <ItemView.Display icon={<IconPerson />} iconAlignment="inline" text="Asif Khan" />;
 const display2 = <ItemView.Display text="Care Position: Primary" />;

--- a/packages/terra-clinical-label-value-view/CHANGELOG.md
+++ b/packages/terra-clinical-label-value-view/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Add comments for ESlint 6
+* Cleaned up imports in examples and test files
 
 3.7.0 - (August 14, 2019)
 ----------

--- a/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/clinical-label-value-view/clinicalLabelValueView.1.doc.jsx
+++ b/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/clinical-label-value-view/clinicalLabelValueView.1.doc.jsx
@@ -3,7 +3,6 @@ import DocTemplate from 'terra-doc-template';
 import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 // Component Source
 import LabelValueViewSrc from '!raw-loader!../../../../src/LabelValueView';
 
@@ -14,7 +13,6 @@ import LabelValueViewNode from '../example/LabelValueViewNode';
 import LabelValueViewNodeSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/LabelValueViewNode';
 import LabelValueViewNodeCustom from '../example/LabelValueViewNodeCustom';
 import LabelValueViewNodeCustomSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/LabelValueViewNodeCustom';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DocPage = () => (
   <DocTemplate

--- a/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/example/LabelValueViewNode.jsx
+++ b/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/example/LabelValueViewNode.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import ItemDisplay from 'terra-clinical-item-display';
 import IconCritical from 'terra-icon/lib/icon/IconCritical';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import LabelValueView from 'terra-clinical-label-value-view/lib/LabelValueView';
+import LabelValueView from 'terra-clinical-label-value-view';
 
 const LabelValueViewNode = () => (
   <div>

--- a/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/example/LabelValueViewNodeCustom.jsx
+++ b/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/example/LabelValueViewNodeCustom.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import LabelValueView from 'terra-clinical-label-value-view/lib/LabelValueView';
+import LabelValueView from 'terra-clinical-label-value-view';
 import classNames from 'classnames/bind';
 import styles from './LabelValueView.module.scss';
 

--- a/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/example/LabelValueViewText.jsx
+++ b/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/example/LabelValueViewText.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import LabelValueView from 'terra-clinical-label-value-view/lib/LabelValueView';
+import LabelValueView from 'terra-clinical-label-value-view';
 
 const LabelValueViewText = () => (
   <div>

--- a/packages/terra-clinical-onset-picker/CHANGELOG.md
+++ b/packages/terra-clinical-onset-picker/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 ### Changed
 * Replaced Object.assign syntax with Object spread syntax
+* Cleaned up imports in examples and test files
 
 4.5.0 - (August 14, 2019)
 ----------

--- a/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/clinical-onset-picker/ClinicalOnsetPicker.1.doc.jsx
+++ b/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/clinical-onset-picker/ClinicalOnsetPicker.1.doc.jsx
@@ -3,7 +3,6 @@ import DocTemplate from 'terra-doc-template';
 import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 // Component Source
 import OnsetPickerSrc from '!raw-loader!../../../../src/OnsetPicker';
 
@@ -14,7 +13,6 @@ import HandledOnset from '../example/HandledOnset';
 import HandledOnsetSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/HandledOnset';
 import OnsetWithHiddenLegend from '../example/OnsetWithHiddenLegend';
 import OnsetWithHiddenLegendSrc from '../example/OnsetWithHiddenLegend';
-/* eslint-enable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-unresolved, import/no-duplicates */
 
 const DocPage = () => (
   <DocTemplate

--- a/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/example/DefaultOnset.jsx
+++ b/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/example/DefaultOnset.jsx
@@ -1,8 +1,6 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import moment from 'moment';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import OnsetPicker from 'terra-clinical-onset-picker/lib/OnsetPicker';
+import OnsetPicker from 'terra-clinical-onset-picker';
 
 const birthdate = moment().subtract(6, 'years');
 const picker = () => (

--- a/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/example/HandledOnset.jsx
+++ b/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/example/HandledOnset.jsx
@@ -1,8 +1,6 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import moment from 'moment';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import OnsetPicker from 'terra-clinical-onset-picker/lib/OnsetPicker';
+import OnsetPicker from 'terra-clinical-onset-picker';
 
 class HandledOnsetExample extends React.Component {
   constructor(props) {

--- a/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/example/OnsetWithHiddenLegend.jsx
+++ b/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/example/OnsetWithHiddenLegend.jsx
@@ -1,8 +1,6 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import moment from 'moment';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved, import/extensions
-import OnsetPicker from 'terra-clinical-onset-picker/lib/OnsetPicker';
+import OnsetPicker from 'terra-clinical-onset-picker';
 
 const OnsetWithHiddenLegend = () => (
   <OnsetPicker

--- a/packages/terra-clinical-onset-picker/tests/jest/OnsetPicker.test.jsx
+++ b/packages/terra-clinical-onset-picker/tests/jest/OnsetPicker.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-/* eslint-disable import/no-extraneous-dependencies */
 import MockDate from 'mockdate';
 import { IntlProvider } from 'react-intl';
 import selectMessages from 'terra-form-select/translations/en-US.json';


### PR DESCRIPTION
### Summary
Closes #552.
