### PR TITLE
Consume dev-site props-table-loader

### DIFF
--- a/dev-site-config/site.config.js
+++ b/dev-site-config/site.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  includePropsTableLoader: true,
+};

--- a/dev-site-config/site.config.js 
+++ b/dev-site-config/site.config.js 
@@ -1,5 +1,0 @@
-const siteConfig = {
-  includePropsTableLoader: true,
-};
-
-module.exports = siteConfig;

--- a/dev-site-config/site.config.js 
+++ b/dev-site-config/site.config.js 
@@ -1,0 +1,5 @@
+const siteConfig = {
+  includePropsTableLoader: true,
+};
+
+module.exports = siteConfig;

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "stylelint-config-terra": "^3.0.0",
     "terra-aggregate-translations": "^1.0.0",
     "terra-base": "^5.0.0",
-    "terra-dev-site": "^6.0.0",
+    "terra-dev-site": "cerner/terra-dev-site#props-table-loader",
     "terra-disclosure-manager": "^4.9.0",
     "terra-toolkit": "^5.0.0",
     "webpack": "^4.30.0",

--- a/packages/terra-clinical-data-grid/CHANGELOG.md
+++ b/packages/terra-clinical-data-grid/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Props table markdown file import added to doc site page
 
 2.10.0 - (September 6, 2019)
 ----------

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/clinicalDataGrid.1.doc.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/clinicalDataGrid.1.doc.jsx
@@ -3,7 +3,6 @@ import DocTemplate from 'terra-doc-template';
 import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 // Component Source
-import DataGridSrc from '!raw-loader!../../../../src/DataGrid';
 import DataGridPropsTable from '!terra-props-table-loader!../../../../src/DataGrid';
 
 const DocPage = () => (
@@ -14,7 +13,6 @@ const DocPage = () => (
     propsTables={[
       {
         componentName: 'DataGrid',
-        componentSrc: DataGridSrc,
         componentProps: DataGridPropsTable,
       },
     ]}

--- a/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/clinicalDataGrid.1.doc.jsx
+++ b/packages/terra-clinical-data-grid/src/terra-dev-site/doc/clinical-data-grid/clinicalDataGrid.1.doc.jsx
@@ -4,6 +4,7 @@ import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 // Component Source
 import DataGridSrc from '!raw-loader!../../../../src/DataGrid';
+import DataGridPropsTable from '!terra-props-table-loader!../../../../src/DataGrid';
 
 const DocPage = () => (
   <DocTemplate
@@ -14,6 +15,7 @@ const DocPage = () => (
       {
         componentName: 'DataGrid',
         componentSrc: DataGridSrc,
+        componentProps: DataGridPropsTable,
       },
     ]}
   />

--- a/packages/terra-clinical-detail-view/CHANGELOG.md
+++ b/packages/terra-clinical-detail-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Props table markdown file import added to doc site page
 
 3.8.0 - (September 6, 2019)
 ----------

--- a/packages/terra-clinical-detail-view/src/terra-dev-site/doc/clinical-detail-view/clinicalDetailView.1.doc.jsx
+++ b/packages/terra-clinical-detail-view/src/terra-dev-site/doc/clinical-detail-view/clinicalDetailView.1.doc.jsx
@@ -7,6 +7,9 @@ import { name } from '../../../../package.json';
 import DetailViewSrc from '!raw-loader!../../../../src/DetailView';
 import DetailListSrc from '!raw-loader!../../../../src/DetailList';
 import DetailListItemSrc from '!raw-loader!../../../../src/DetailListItem';
+import DetailViewPropsTable from '!terra-props-table-loader!../../../../src/DetailView';
+import DetailListPropsTable from '!terra-props-table-loader!../../../../src/DetailList';
+import DetailListItemPropsTable from '!terra-props-table-loader!../../../../src/DetailListItem';
 
 // Example files
 import DetailViewDivided from '../example/DetailViewDivided';
@@ -42,14 +45,17 @@ const DocPage = () => (
       {
         componentName: 'Detail View',
         componentSrc: DetailViewSrc,
+        componentProps: DetailViewPropsTable,
       },
       {
         componentName: 'Detail List',
         componentSrc: DetailListSrc,
+        componentProps: DetailListPropsTable,
       },
       {
         componentName: 'Detail List Item',
         componentSrc: DetailListItemSrc,
+        componentProps: DetailListItemPropsTable,
       },
     ]}
   />

--- a/packages/terra-clinical-detail-view/src/terra-dev-site/doc/clinical-detail-view/clinicalDetailView.1.doc.jsx
+++ b/packages/terra-clinical-detail-view/src/terra-dev-site/doc/clinical-detail-view/clinicalDetailView.1.doc.jsx
@@ -4,9 +4,6 @@ import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
 // Component Source
-import DetailViewSrc from '!raw-loader!../../../../src/DetailView';
-import DetailListSrc from '!raw-loader!../../../../src/DetailList';
-import DetailListItemSrc from '!raw-loader!../../../../src/DetailListItem';
 import DetailViewPropsTable from '!terra-props-table-loader!../../../../src/DetailView';
 import DetailListPropsTable from '!terra-props-table-loader!../../../../src/DetailList';
 import DetailListItemPropsTable from '!terra-props-table-loader!../../../../src/DetailListItem';
@@ -44,17 +41,14 @@ const DocPage = () => (
     propsTables={[
       {
         componentName: 'Detail View',
-        componentSrc: DetailViewSrc,
         componentProps: DetailViewPropsTable,
       },
       {
         componentName: 'Detail List',
-        componentSrc: DetailListSrc,
         componentProps: DetailListPropsTable,
       },
       {
         componentName: 'Detail List Item',
-        componentSrc: DetailListItemSrc,
         componentProps: DetailListItemPropsTable,
       },
     ]}

--- a/packages/terra-clinical-header/CHANGELOG.md
+++ b/packages/terra-clinical-header/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Props table markdown file import added to doc site page
 
 3.8.0 - (September 6, 2019)
 ----------

--- a/packages/terra-clinical-header/src/terra-dev-site/doc/clinical-header/clinicalHeader.1.doc.jsx
+++ b/packages/terra-clinical-header/src/terra-dev-site/doc/clinical-header/clinicalHeader.1.doc.jsx
@@ -4,7 +4,6 @@ import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
 // Component Source
-import HeaderSrc from '!raw-loader!../../../../src/Header';
 import HeaderPropsTable from '!terra-props-table-loader!../../../../src/Header';
 
 // Example Files
@@ -54,7 +53,6 @@ const DocPage = () => (
     propsTables={[
       {
         componentName: 'Header',
-        componentSrc: HeaderSrc,
         componentProps: HeaderPropsTable,
       },
     ]}

--- a/packages/terra-clinical-header/src/terra-dev-site/doc/clinical-header/clinicalHeader.1.doc.jsx
+++ b/packages/terra-clinical-header/src/terra-dev-site/doc/clinical-header/clinicalHeader.1.doc.jsx
@@ -5,6 +5,7 @@ import { name } from '../../../../package.json';
 
 // Component Source
 import HeaderSrc from '!raw-loader!../../../../src/Header';
+import HeaderPropsTable from '!terra-props-table-loader!../../../../src/Header';
 
 // Example Files
 import TitleHeader from '../example/TitleHeader';
@@ -54,6 +55,7 @@ const DocPage = () => (
       {
         componentName: 'Header',
         componentSrc: HeaderSrc,
+        componentProps: HeaderPropsTable,
       },
     ]}
   />

--- a/packages/terra-clinical-item-collection/CHANGELOG.md
+++ b/packages/terra-clinical-item-collection/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Props table markdown file import added to doc site page
 
 4.7.0 - (September 6, 2019)
 ----------

--- a/packages/terra-clinical-item-collection/src/terra-dev-site/doc/clinical-item-collection/clinicalItemCollection.1.doc.jsx
+++ b/packages/terra-clinical-item-collection/src/terra-dev-site/doc/clinical-item-collection/clinicalItemCollection.1.doc.jsx
@@ -6,6 +6,8 @@ import { name } from '../../../../package.json';
 // Component Source
 import ItemCollectionSrc from '!raw-loader!../../../../src/ItemCollection';
 import ItemSrc from '!raw-loader!../../../../src/Item';
+import ItemCollectionPropsTable from '!terra-props-table-loader!../../../../src/ItemCollection';
+import ItemPropsTable from '!terra-props-table-loader!../../../../src/Item';
 
 // Example Files
 import ItemCollectionExample from '../example/ItemCollectionExample';
@@ -27,10 +29,12 @@ const DocPage = () => (
       {
         componentName: 'Item Collection',
         componentSrc: ItemCollectionSrc,
+        componentProps: ItemCollectionPropsTable,
       },
       {
         componentName: 'Item',
         componentSrc: ItemSrc,
+        componentProps: ItemPropsTable,
       },
     ]}
   />

--- a/packages/terra-clinical-item-collection/src/terra-dev-site/doc/clinical-item-collection/clinicalItemCollection.1.doc.jsx
+++ b/packages/terra-clinical-item-collection/src/terra-dev-site/doc/clinical-item-collection/clinicalItemCollection.1.doc.jsx
@@ -4,8 +4,6 @@ import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
 // Component Source
-import ItemCollectionSrc from '!raw-loader!../../../../src/ItemCollection';
-import ItemSrc from '!raw-loader!../../../../src/Item';
 import ItemCollectionPropsTable from '!terra-props-table-loader!../../../../src/ItemCollection';
 import ItemPropsTable from '!terra-props-table-loader!../../../../src/Item';
 
@@ -28,12 +26,10 @@ const DocPage = () => (
     propsTables={[
       {
         componentName: 'Item Collection',
-        componentSrc: ItemCollectionSrc,
         componentProps: ItemCollectionPropsTable,
       },
       {
         componentName: 'Item',
-        componentSrc: ItemSrc,
         componentProps: ItemPropsTable,
       },
     ]}

--- a/packages/terra-clinical-item-display/CHANGELOG.md
+++ b/packages/terra-clinical-item-display/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Props table markdown file import added to doc site page
 
 3.7.0 - (September 6, 2019)
 ----------

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.jsx
@@ -6,6 +6,9 @@ import { name } from '../../../../package.json';
 // Component Source
 import ItemDisplaySrc from '!raw-loader!../../../../src/ItemDisplay';
 import CommentSrc from '!raw-loader!../../../../src/ItemComment';
+import ItemDisplayPropsTable from '!terra-props-table-loader!../../../../src/ItemDisplay';
+import CommentPropsTable from '!terra-props-table-loader!../../../../src/ItemComment';
+
 
 // Example Files
 import TextStyles from '../example/TextStyles';
@@ -56,10 +59,12 @@ const DocPage = () => (
       {
         componentName: 'Item Display',
         componentSrc: ItemDisplaySrc,
+        componentProps: ItemDisplayPropsTable,
       },
       {
         componentName: 'Item Comment',
         componentSrc: CommentSrc,
+        componentProps: CommentPropsTable,
       },
     ]}
   />

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.jsx
@@ -4,8 +4,6 @@ import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
 // Component Source
-import ItemDisplaySrc from '!raw-loader!../../../../src/ItemDisplay';
-import CommentSrc from '!raw-loader!../../../../src/ItemComment';
 import ItemDisplayPropsTable from '!terra-props-table-loader!../../../../src/ItemDisplay';
 import CommentPropsTable from '!terra-props-table-loader!../../../../src/ItemComment';
 
@@ -58,12 +56,10 @@ const DocPage = () => (
     propsTables={[
       {
         componentName: 'Item Display',
-        componentSrc: ItemDisplaySrc,
         componentProps: ItemDisplayPropsTable,
       },
       {
         componentName: 'Item Comment',
-        componentSrc: CommentSrc,
         componentProps: CommentPropsTable,
       },
     ]}

--- a/packages/terra-clinical-item-view/CHANGELOG.md
+++ b/packages/terra-clinical-item-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Props table markdown file import added to doc site page
 
 3.7.0 - (September 6, 2019)
 ----------

--- a/packages/terra-clinical-item-view/src/terra-dev-site/doc/clinical-item-view/clinicalItemView.1.doc.jsx
+++ b/packages/terra-clinical-item-view/src/terra-dev-site/doc/clinical-item-view/clinicalItemView.1.doc.jsx
@@ -6,7 +6,6 @@ import ItemViewTwoColumnDocs from '../../../../docs/item-view-two-column.md';
 import { name } from '../../../../package.json';
 
 // Component Source
-import ItemViewSrc from '!raw-loader!../../../../src/ItemView.jsx';
 import ItemViewPropsTable from '!terra-props-table-loader!../../../../src/ItemView.jsx';
 
 // Example Files
@@ -64,7 +63,6 @@ const DocPage = () => (
     propsTables={[
       {
         componentName: 'Item View',
-        componentSrc: ItemViewSrc,
         componentProps: ItemViewPropsTable,
       },
     ]}

--- a/packages/terra-clinical-item-view/src/terra-dev-site/doc/clinical-item-view/clinicalItemView.1.doc.jsx
+++ b/packages/terra-clinical-item-view/src/terra-dev-site/doc/clinical-item-view/clinicalItemView.1.doc.jsx
@@ -7,6 +7,7 @@ import { name } from '../../../../package.json';
 
 // Component Source
 import ItemViewSrc from '!raw-loader!../../../../src/ItemView.jsx';
+import ItemViewPropsTable from '!terra-props-table-loader!../../../../src/ItemView.jsx';
 
 // Example Files
 import ItemViewStandard from '../example/ItemViewStandard';
@@ -64,6 +65,7 @@ const DocPage = () => (
       {
         componentName: 'Item View',
         componentSrc: ItemViewSrc,
+        componentProps: ItemViewPropsTable,
       },
     ]}
   />

--- a/packages/terra-clinical-label-value-view/CHANGELOG.md
+++ b/packages/terra-clinical-label-value-view/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Props table markdown file import added to doc site page
 
 3.8.0 - (September 6, 2019)
 ----------

--- a/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/clinical-label-value-view/clinicalLabelValueView.1.doc.jsx
+++ b/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/clinical-label-value-view/clinicalLabelValueView.1.doc.jsx
@@ -5,6 +5,7 @@ import { name } from '../../../../package.json';
 
 // Component Source
 import LabelValueViewSrc from '!raw-loader!../../../../src/LabelValueView';
+import LabelValueViewPropsTable from '!terra-props-table-loader!../../../../src/LabelValueView';
 
 // Example Files
 import LabelValueViewText from '../example/LabelValueViewText';
@@ -40,6 +41,7 @@ const DocPage = () => (
       {
         componentName: 'Label Value View',
         componentSrc: LabelValueViewSrc,
+        componentProps: LabelValueViewPropsTable,
       },
     ]}
   />

--- a/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/clinical-label-value-view/clinicalLabelValueView.1.doc.jsx
+++ b/packages/terra-clinical-label-value-view/src/terra-dev-site/doc/clinical-label-value-view/clinicalLabelValueView.1.doc.jsx
@@ -4,7 +4,6 @@ import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
 // Component Source
-import LabelValueViewSrc from '!raw-loader!../../../../src/LabelValueView';
 import LabelValueViewPropsTable from '!terra-props-table-loader!../../../../src/LabelValueView';
 
 // Example Files
@@ -40,7 +39,6 @@ const DocPage = () => (
     propsTables={[
       {
         componentName: 'Label Value View',
-        componentSrc: LabelValueViewSrc,
         componentProps: LabelValueViewPropsTable,
       },
     ]}

--- a/packages/terra-clinical-onset-picker/CHANGELOG.md
+++ b/packages/terra-clinical-onset-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Added
+* Props table markdown file import added to doc site page
 
 4.6.0 - (September 6, 2019)
 ----------

--- a/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/clinical-onset-picker/ClinicalOnsetPicker.1.doc.jsx
+++ b/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/clinical-onset-picker/ClinicalOnsetPicker.1.doc.jsx
@@ -5,6 +5,7 @@ import { name } from '../../../../package.json';
 
 // Component Source
 import OnsetPickerSrc from '!raw-loader!../../../../src/OnsetPicker';
+import OnsetPickerPropsTable from '!terra-props-table-loader!../../../../src/OnsetPicker';
 
 // Example Files
 import DefaultOnset from '../example/DefaultOnset';
@@ -40,6 +41,7 @@ const DocPage = () => (
       {
         componentName: 'Onset Picker',
         componentSrc: OnsetPickerSrc,
+        componentProps: OnsetPickerPropsTable,
       },
     ]}
   />

--- a/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/clinical-onset-picker/ClinicalOnsetPicker.1.doc.jsx
+++ b/packages/terra-clinical-onset-picker/src/terra-dev-site/doc/clinical-onset-picker/ClinicalOnsetPicker.1.doc.jsx
@@ -4,7 +4,6 @@ import ReadMe from '../../../../docs/README.md';
 import { name } from '../../../../package.json';
 
 // Component Source
-import OnsetPickerSrc from '!raw-loader!../../../../src/OnsetPicker';
 import OnsetPickerPropsTable from '!terra-props-table-loader!../../../../src/OnsetPicker';
 
 // Example Files
@@ -40,7 +39,6 @@ const DocPage = () => (
     propsTables={[
       {
         componentName: 'Onset Picker',
-        componentSrc: OnsetPickerSrc,
         componentProps: OnsetPickerPropsTable,
       },
     ]}


### PR DESCRIPTION
### Summary
Testing the new custom react-docgen based props-table-loader from terra-dev-site