### PR TITLE
Consume terra-props-loader branch of terra-dev-site

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "stylelint-config-terra": "^3.0.0",
     "terra-aggregate-translations": "^1.0.0",
     "terra-base": "^5.0.0",
-    "terra-dev-site": "^6.0.0",
+    "terra-dev-site": "cerner/terra-dev-site#props-table-loader",
     "terra-disclosure-manager": "^4.9.0",
     "terra-toolkit": "^5.0.0",
     "webpack": "^4.30.0",


### PR DESCRIPTION
### Summary
Testing branch - Do Not Merge

This branch consumes the terra-props-table-loader branch but does not opt-in to using it.