### PR TITLE
Remove terra-i18n as a dependency since it is not being used or needed.

### DIFF
--- a/packages/terra-clinical-onset-picker/CHANGELOG.md
+++ b/packages/terra-clinical-onset-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed terra-i18n as a dependency since it is not being used.
 
 4.7.0 - (September 19, 2019)
 ----------

--- a/packages/terra-clinical-onset-picker/package.json
+++ b/packages/terra-clinical-onset-picker/package.json
@@ -39,8 +39,7 @@
     "terra-form-field": "^3.0.0",
     "terra-form-fieldset": "^2.0.0",
     "terra-form-input": "^2.0.0",
-    "terra-form-select": "^5.0.0",
-    "terra-i18n": "^3.0.0"
+    "terra-form-select": "^5.0.0"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",


### PR DESCRIPTION
### Summary
Now that all the components with en-CA are released, we now can see that terra-aggregate-translation reports that  the `Terra/terra-clinical/node_modules/terra-i18n/translations/en-CA.json.` translation file is missing. The en-CA.json for terra-i18n was added in version 4.15.0 but terra-onset-picker has a dependency on version 3.X.X. After further digging, it does not appear that terra-onset-picker uses terra-i18n or has a need for it. Therefore, removing terra-i18n as a dependency terra-onset-picker.