### PR TITLE
Remove un-used keycodes file

### DIFF
--- a/packages/terra-clinical-data-grid/CHANGELOG.md
+++ b/packages/terra-clinical-data-grid/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Removed
+* Removed used keycodes file
 
 2.11.0 - (September 19, 2019)
 ----------

--- a/packages/terra-clinical-data-grid/src/utils/keycodes.js
+++ b/packages/terra-clinical-data-grid/src/utils/keycodes.js
@@ -1,9 +1,0 @@
-const KEYCODES = {
-  ENTER: 13,
-  SPACE: 32,
-  TAB: 9,
-  SHIFT: 16,
-};
-
-export default KEYCODES;
-export { KEYCODES };


### PR DESCRIPTION
### Summary
In https://github.com/cerner/terra-clinical/pull/479 we removed custom keycodes in favor of using `keycodes-js`. Looks like this file was missed in cleanup.