### PR TITLE
Label `intl` Prop as Private

### DIFF
--- a/packages/terra-clinical-data-grid/CHANGELOG.md
+++ b/packages/terra-clinical-data-grid/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Mark `intl` prop as private since it is retrieved from the context automatically by injectIntl.
 
 2.12.0 - (September 26, 2019)
 ------------------

--- a/packages/terra-clinical-data-grid/src/DataGrid.jsx
+++ b/packages/terra-clinical-data-grid/src/DataGrid.jsx
@@ -98,6 +98,7 @@ const propTypes = {
    */
   fill: PropTypes.bool,
   /**
+   * @private
    * The intl object containing translations. This is retrieved from the context automatically by injectIntl.
    */
   intl: intlShape.isRequired,

--- a/packages/terra-clinical-onset-picker/CHANGELOG.md
+++ b/packages/terra-clinical-onset-picker/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Changed
+* Mark `intl` prop as private since it is retrieved from the context automatically by injectIntl.
 
 4.10.0 - (November 7, 2019)
 ------------------

--- a/packages/terra-clinical-onset-picker/src/OnsetPicker.jsx
+++ b/packages/terra-clinical-onset-picker/src/OnsetPicker.jsx
@@ -35,59 +35,50 @@ const propTypes = {
    * The date unit of the age value. One of `weeks`, `months`, or `years`.
    */
   ageUnit: PropTypes.oneOf(Object.values(AgeUnits)),
-
   /**
    * The ISO 8601 **DATE ONLY** string representation of the birth date to calculate an onset date for the `age` precision.
    * Also limits the earliest possible date that can be selected for an onset date for `year`, `month`, and `date` precision.
    */
   birthdate: PropTypes.string.isRequired,
-
   /**
    * The granularity of the onset date. One of `age`, `year`, `month`, or `date` is accepted.
    */
   granularity: PropTypes.oneOf(Object.values(GranularityOptions)),
-
   /**
    * The id of the onset picker. Used as the base for other required id/name in sub-components.
    */
   id: PropTypes.string.isRequired,
-
   /**
    * The precision of the onset date. This should be one of precisions passed to the precisionSet prop.
    * One of `on/at`, `about`, `before`, `after`, or `unknown`.
    */
   precision: PropTypes.oneOf(Object.values(PrecisionOptions)),
-
   /**
    * The set of precisions that can be used with the onset picker.
    * Combination of `on/at`, `about`, `before`, `after`, and `unknown`.
    * Order of precisions determines order in precision select.
    */
   precisionSet: PropTypes.arrayOf(PropTypes.oneOf(Object.values(PrecisionOptions))),
-
   /**
    * The ISO 8601 **DATE ONLY** string representation of the onset date to view/modify.
    */
   onsetDate: PropTypes.string,
-
   /**
    * A callback function to execute when any value of the onsetDate is changed.
    * The first parameter is a Object that contains `precision`, `granularity`, `onsetDate`, and `ageUnit`.
    * `ageUnit` is only present if the granularity is 'age'.
    */
   onsetOnChange: PropTypes.func,
-
   /**
    * Legend for the Onset Picker field group.
    */
   legend: PropTypes.string,
-
   /**
    * Whether or not the legend is visible. Use this props to hide a legend while still creating it on the DOM for accessibility.
    */
   isLegendHidden: PropTypes.bool,
-
   /**
+   * @private
    * The intl object containing translations. This is retrieved from the context automatically by injectIntl.
    */
   intl: intlShape.isRequired,

--- a/packages/terra-clinical-onset-picker/tests/jest/__snapshots__/OnsetPicker.test.jsx.snap
+++ b/packages/terra-clinical-onset-picker/tests/jest/__snapshots__/OnsetPicker.test.jsx.snap
@@ -140,11 +140,11 @@ exports[`should render a default onset picker with specified onset date 1`] = `
           </div>
         </div>
         <div
-          aria-describedby="terra-select-screen-reader-description-8"
+          aria-describedby="terra-select-screen-reader-description-9"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
-          aria-labelledby="terra-select-screen-reader-label-5 terra-select-screen-reader-display-6 terra-select-screen-reader-placeholder-7"
+          aria-labelledby="terra-select-screen-reader-label-6 terra-select-screen-reader-display-7 terra-select-screen-reader-placeholder-8"
           aria-required="false"
           class="select default"
           data-terra-select="true"
@@ -158,12 +158,12 @@ exports[`should render a default onset picker with specified onset date 1`] = `
             hidden=""
           >
             <span
-              id="terra-select-screen-reader-label-5"
+              id="terra-select-screen-reader-label-6"
             >
               Select a date granularity
             </span>
             <span
-              id="terra-select-screen-reader-description-8"
+              id="terra-select-screen-reader-description-9"
             >
               List of 4 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
             </span>
@@ -175,7 +175,7 @@ exports[`should render a default onset picker with specified onset date 1`] = `
           >
             <div
               class="placeholder"
-              id="terra-select-screen-reader-placeholder-7"
+              id="terra-select-screen-reader-placeholder-8"
             >
               Granularity
             </div>
@@ -249,11 +249,11 @@ exports[`should render only a select when supplied with the UNKNOWN precision 1`
           </div>
         </div>
         <div
-          aria-describedby="terra-select-screen-reader-description-12"
+          aria-describedby="terra-select-screen-reader-description-14"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
-          aria-labelledby="terra-select-screen-reader-label-9 terra-select-screen-reader-display-10 terra-select-screen-reader-placeholder-11"
+          aria-labelledby="terra-select-screen-reader-label-11 terra-select-screen-reader-display-12 terra-select-screen-reader-placeholder-13"
           aria-required="false"
           class="select default"
           data-terra-select="true"
@@ -267,12 +267,12 @@ exports[`should render only a select when supplied with the UNKNOWN precision 1`
             hidden=""
           >
             <span
-              id="terra-select-screen-reader-label-9"
+              id="terra-select-screen-reader-label-11"
             >
               Select a date precision
             </span>
             <span
-              id="terra-select-screen-reader-description-12"
+              id="terra-select-screen-reader-description-14"
             >
               List of 5 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
             </span>
@@ -283,7 +283,7 @@ exports[`should render only a select when supplied with the UNKNOWN precision 1`
             role="textbox"
           >
             <span
-              id="terra-select-screen-reader-display-10"
+              id="terra-select-screen-reader-display-12"
             >
               Unknown
             </span>
@@ -356,11 +356,11 @@ exports[`should render only the supplied precisions 1`] = `
           </div>
         </div>
         <div
-          aria-describedby="terra-select-screen-reader-description-48"
+          aria-describedby="terra-select-screen-reader-description-59"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
-          aria-labelledby="terra-select-screen-reader-label-45 terra-select-screen-reader-display-46 terra-select-screen-reader-placeholder-47"
+          aria-labelledby="terra-select-screen-reader-label-56 terra-select-screen-reader-display-57 terra-select-screen-reader-placeholder-58"
           aria-required="false"
           class="select default"
           data-terra-select="true"
@@ -374,12 +374,12 @@ exports[`should render only the supplied precisions 1`] = `
             hidden=""
           >
             <span
-              id="terra-select-screen-reader-label-45"
+              id="terra-select-screen-reader-label-56"
             >
               Select a date precision
             </span>
             <span
-              id="terra-select-screen-reader-description-48"
+              id="terra-select-screen-reader-description-59"
             >
               List of 3 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
             </span>
@@ -391,7 +391,7 @@ exports[`should render only the supplied precisions 1`] = `
           >
             <div
               class="placeholder"
-              id="terra-select-screen-reader-placeholder-47"
+              id="terra-select-screen-reader-placeholder-58"
             >
               Precision
             </div>
@@ -449,11 +449,11 @@ exports[`should render only the supplied precisions 1`] = `
           </div>
         </div>
         <div
-          aria-describedby="terra-select-screen-reader-description-52"
+          aria-describedby="terra-select-screen-reader-description-64"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
-          aria-labelledby="terra-select-screen-reader-label-49 terra-select-screen-reader-display-50 terra-select-screen-reader-placeholder-51"
+          aria-labelledby="terra-select-screen-reader-label-61 terra-select-screen-reader-display-62 terra-select-screen-reader-placeholder-63"
           aria-required="false"
           class="select default"
           data-terra-select="true"
@@ -467,12 +467,12 @@ exports[`should render only the supplied precisions 1`] = `
             hidden=""
           >
             <span
-              id="terra-select-screen-reader-label-49"
+              id="terra-select-screen-reader-label-61"
             >
               Select a date granularity
             </span>
             <span
-              id="terra-select-screen-reader-description-52"
+              id="terra-select-screen-reader-description-64"
             >
               List of 4 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
             </span>
@@ -484,7 +484,7 @@ exports[`should render only the supplied precisions 1`] = `
           >
             <div
               class="placeholder"
-              id="terra-select-screen-reader-placeholder-51"
+              id="terra-select-screen-reader-placeholder-63"
             >
               Granularity
             </div>
@@ -558,11 +558,11 @@ exports[`should render the same when onChange function is supplied 1`] = `
           </div>
         </div>
         <div
-          aria-describedby="terra-select-screen-reader-description-40"
+          aria-describedby="terra-select-screen-reader-description-49"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
-          aria-labelledby="terra-select-screen-reader-label-37 terra-select-screen-reader-display-38 terra-select-screen-reader-placeholder-39"
+          aria-labelledby="terra-select-screen-reader-label-46 terra-select-screen-reader-display-47 terra-select-screen-reader-placeholder-48"
           aria-required="false"
           class="select default"
           data-terra-select="true"
@@ -576,12 +576,12 @@ exports[`should render the same when onChange function is supplied 1`] = `
             hidden=""
           >
             <span
-              id="terra-select-screen-reader-label-37"
+              id="terra-select-screen-reader-label-46"
             >
               Select a date precision
             </span>
             <span
-              id="terra-select-screen-reader-description-40"
+              id="terra-select-screen-reader-description-49"
             >
               List of 5 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
             </span>
@@ -593,7 +593,7 @@ exports[`should render the same when onChange function is supplied 1`] = `
           >
             <div
               class="placeholder"
-              id="terra-select-screen-reader-placeholder-39"
+              id="terra-select-screen-reader-placeholder-48"
             >
               Precision
             </div>
@@ -651,11 +651,11 @@ exports[`should render the same when onChange function is supplied 1`] = `
           </div>
         </div>
         <div
-          aria-describedby="terra-select-screen-reader-description-44"
+          aria-describedby="terra-select-screen-reader-description-54"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
-          aria-labelledby="terra-select-screen-reader-label-41 terra-select-screen-reader-display-42 terra-select-screen-reader-placeholder-43"
+          aria-labelledby="terra-select-screen-reader-label-51 terra-select-screen-reader-display-52 terra-select-screen-reader-placeholder-53"
           aria-required="false"
           class="select default"
           data-terra-select="true"
@@ -669,12 +669,12 @@ exports[`should render the same when onChange function is supplied 1`] = `
             hidden=""
           >
             <span
-              id="terra-select-screen-reader-label-41"
+              id="terra-select-screen-reader-label-51"
             >
               Select a date granularity
             </span>
             <span
-              id="terra-select-screen-reader-description-44"
+              id="terra-select-screen-reader-description-54"
             >
               List of 4 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
             </span>
@@ -686,7 +686,7 @@ exports[`should render the same when onChange function is supplied 1`] = `
           >
             <div
               class="placeholder"
-              id="terra-select-screen-reader-placeholder-43"
+              id="terra-select-screen-reader-placeholder-53"
             >
               Granularity
             </div>
@@ -760,11 +760,11 @@ exports[`should render with age inputs filled in when supplied 1`] = `
           </div>
         </div>
         <div
-          aria-describedby="terra-select-screen-reader-description-28"
+          aria-describedby="terra-select-screen-reader-description-34"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
-          aria-labelledby="terra-select-screen-reader-label-25 terra-select-screen-reader-display-26 terra-select-screen-reader-placeholder-27"
+          aria-labelledby="terra-select-screen-reader-label-31 terra-select-screen-reader-display-32 terra-select-screen-reader-placeholder-33"
           aria-required="false"
           class="select default"
           data-terra-select="true"
@@ -778,12 +778,12 @@ exports[`should render with age inputs filled in when supplied 1`] = `
             hidden=""
           >
             <span
-              id="terra-select-screen-reader-label-25"
+              id="terra-select-screen-reader-label-31"
             >
               Select a date precision
             </span>
             <span
-              id="terra-select-screen-reader-description-28"
+              id="terra-select-screen-reader-description-34"
             >
               List of 5 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
             </span>
@@ -794,7 +794,7 @@ exports[`should render with age inputs filled in when supplied 1`] = `
             role="textbox"
           >
             <span
-              id="terra-select-screen-reader-display-26"
+              id="terra-select-screen-reader-display-32"
             >
               Before
             </span>
@@ -852,11 +852,11 @@ exports[`should render with age inputs filled in when supplied 1`] = `
           </div>
         </div>
         <div
-          aria-describedby="terra-select-screen-reader-description-32"
+          aria-describedby="terra-select-screen-reader-description-39"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
-          aria-labelledby="terra-select-screen-reader-label-29 terra-select-screen-reader-display-30 terra-select-screen-reader-placeholder-31"
+          aria-labelledby="terra-select-screen-reader-label-36 terra-select-screen-reader-display-37 terra-select-screen-reader-placeholder-38"
           aria-required="false"
           class="select default"
           data-terra-select="true"
@@ -870,12 +870,12 @@ exports[`should render with age inputs filled in when supplied 1`] = `
             hidden=""
           >
             <span
-              id="terra-select-screen-reader-label-29"
+              id="terra-select-screen-reader-label-36"
             >
               Select a date granularity
             </span>
             <span
-              id="terra-select-screen-reader-description-32"
+              id="terra-select-screen-reader-description-39"
             >
               List of 4 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
             </span>
@@ -886,7 +886,7 @@ exports[`should render with age inputs filled in when supplied 1`] = `
             role="textbox"
           >
             <span
-              id="terra-select-screen-reader-display-30"
+              id="terra-select-screen-reader-display-37"
             >
               Age
             </span>
@@ -992,11 +992,11 @@ exports[`should render with age inputs filled in when supplied 1`] = `
             </div>
           </div>
           <div
-            aria-describedby="terra-select-screen-reader-description-36"
+            aria-describedby="terra-select-screen-reader-description-44"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
-            aria-labelledby="terra-select-screen-reader-label-33 terra-select-screen-reader-display-34 terra-select-screen-reader-placeholder-35"
+            aria-labelledby="terra-select-screen-reader-label-41 terra-select-screen-reader-display-42 terra-select-screen-reader-placeholder-43"
             aria-required="false"
             class="select default"
             data-terra-select="true"
@@ -1010,12 +1010,12 @@ exports[`should render with age inputs filled in when supplied 1`] = `
               hidden=""
             >
               <span
-                id="terra-select-screen-reader-label-33"
+                id="terra-select-screen-reader-label-41"
               >
                 Select an age precision
               </span>
               <span
-                id="terra-select-screen-reader-description-36"
+                id="terra-select-screen-reader-description-44"
               >
                 List of 3 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
               </span>
@@ -1026,7 +1026,7 @@ exports[`should render with age inputs filled in when supplied 1`] = `
               role="textbox"
             >
               <span
-                id="terra-select-screen-reader-display-34"
+                id="terra-select-screen-reader-display-42"
               >
                 Year(s)
               </span>
@@ -1100,11 +1100,11 @@ exports[`should render with non default inputs when supplied 1`] = `
           </div>
         </div>
         <div
-          aria-describedby="terra-select-screen-reader-description-16"
+          aria-describedby="terra-select-screen-reader-description-19"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
-          aria-labelledby="terra-select-screen-reader-label-13 terra-select-screen-reader-display-14 terra-select-screen-reader-placeholder-15"
+          aria-labelledby="terra-select-screen-reader-label-16 terra-select-screen-reader-display-17 terra-select-screen-reader-placeholder-18"
           aria-required="false"
           class="select default"
           data-terra-select="true"
@@ -1118,12 +1118,12 @@ exports[`should render with non default inputs when supplied 1`] = `
             hidden=""
           >
             <span
-              id="terra-select-screen-reader-label-13"
+              id="terra-select-screen-reader-label-16"
             >
               Select a date precision
             </span>
             <span
-              id="terra-select-screen-reader-description-16"
+              id="terra-select-screen-reader-description-19"
             >
               List of 5 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
             </span>
@@ -1134,7 +1134,7 @@ exports[`should render with non default inputs when supplied 1`] = `
             role="textbox"
           >
             <span
-              id="terra-select-screen-reader-display-14"
+              id="terra-select-screen-reader-display-17"
             >
               Before
             </span>
@@ -1192,11 +1192,11 @@ exports[`should render with non default inputs when supplied 1`] = `
           </div>
         </div>
         <div
-          aria-describedby="terra-select-screen-reader-description-20"
+          aria-describedby="terra-select-screen-reader-description-24"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
-          aria-labelledby="terra-select-screen-reader-label-17 terra-select-screen-reader-display-18 terra-select-screen-reader-placeholder-19"
+          aria-labelledby="terra-select-screen-reader-label-21 terra-select-screen-reader-display-22 terra-select-screen-reader-placeholder-23"
           aria-required="false"
           class="select default"
           data-terra-select="true"
@@ -1210,12 +1210,12 @@ exports[`should render with non default inputs when supplied 1`] = `
             hidden=""
           >
             <span
-              id="terra-select-screen-reader-label-17"
+              id="terra-select-screen-reader-label-21"
             >
               Select a date granularity
             </span>
             <span
-              id="terra-select-screen-reader-description-20"
+              id="terra-select-screen-reader-description-24"
             >
               List of 4 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
             </span>
@@ -1226,7 +1226,7 @@ exports[`should render with non default inputs when supplied 1`] = `
             role="textbox"
           >
             <span
-              id="terra-select-screen-reader-display-18"
+              id="terra-select-screen-reader-display-22"
             >
               Year
             </span>
@@ -1285,11 +1285,11 @@ exports[`should render with non default inputs when supplied 1`] = `
             </div>
           </div>
           <div
-            aria-describedby="terra-select-screen-reader-description-24"
+            aria-describedby="terra-select-screen-reader-description-29"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
-            aria-labelledby="terra-select-screen-reader-label-21 terra-select-screen-reader-display-22 terra-select-screen-reader-placeholder-23"
+            aria-labelledby="terra-select-screen-reader-label-26 terra-select-screen-reader-display-27 terra-select-screen-reader-placeholder-28"
             aria-required="false"
             class="select default"
             data-terra-select="true"
@@ -1303,12 +1303,12 @@ exports[`should render with non default inputs when supplied 1`] = `
               hidden=""
             >
               <span
-                id="terra-select-screen-reader-label-21"
+                id="terra-select-screen-reader-label-26"
               >
                 Select a year
               </span>
               <span
-                id="terra-select-screen-reader-description-24"
+                id="terra-select-screen-reader-description-29"
               >
                 List of 7 options. Use up and down arrow keys to navigate through options. Press enter to select an option.
               </span>
@@ -1319,7 +1319,7 @@ exports[`should render with non default inputs when supplied 1`] = `
               role="textbox"
             >
               <span
-                id="terra-select-screen-reader-display-22"
+                id="terra-select-screen-reader-display-27"
               >
                 2014
               </span>


### PR DESCRIPTION
### Summary
Mark `intl` prop as private since it is retrieved from the context automatically by injectIntl. 