### PR TITLE
Remove yarn ref in docs 

### DIFF
--- a/packages/terra-clinical-item-collection/CHANGELOG.md
+++ b/packages/terra-clinical-item-collection/CHANGELOG.md
@@ -3,6 +3,8 @@ ChangeLog
 
 Unreleased
 ----------
+### Removed
+* Removed yarn reference in docs
 
 4.9.0 - (September 26, 2019)
 ------------------

--- a/packages/terra-clinical-item-collection/docs/README.md
+++ b/packages/terra-clinical-item-collection/docs/README.md
@@ -16,7 +16,6 @@ Additionally, this component will export the ItemView.Display and ItemView.Comme
 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install terra-clinical-item-collection`
-  - `yarn add terra-clinical-item-collection`
 
 ## Component Features
 * [Cross-Browser Support](https://github.com/cerner/terra-ui/blob/master/src/terra-dev-site/contributing/ComponentStandards.e.contributing.md#cross-browser-support)


### PR DESCRIPTION
### Summary
Remove yarn reference in docs. We don't support yarn first-class.