### PR TITLE
[terra-clinical-data-grid][terra-clinical-item-collection] Updated keycode-js to v2

### DIFF
--- a/packages/terra-clinical-data-grid/CHANGELOG.md
+++ b/packages/terra-clinical-data-grid/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Fixed
  * Fixed broken links in documentation.
 
+* Changed
+ * Updated the 'keycode-js' version from '^1.0.4' to '^2.0.1'.
+
 ## 2.30.0 - (December 8, 2020)
 
 * Changed

--- a/packages/terra-clinical-data-grid/CHANGELOG.md
+++ b/packages/terra-clinical-data-grid/CHANGELOG.md
@@ -6,7 +6,7 @@
  * Fixed broken links in documentation.
 
 * Changed
- * Updated the 'keycode-js' version from '^1.0.4' to '^2.0.1'.
+ * Updated the 'keycode-js' version from '^1.0.4' to '^3.1.0'.
 
 ## 2.30.0 - (December 8, 2020)
 

--- a/packages/terra-clinical-data-grid/package.json
+++ b/packages/terra-clinical-data-grid/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "keycode-js": "^2.0.1",
+    "keycode-js": "^3.1.0",
     "memoize-one": "^4.0.0",
     "prop-types": "^15.5.8",
     "react-draggable": "^3.0.5",

--- a/packages/terra-clinical-data-grid/package.json
+++ b/packages/terra-clinical-data-grid/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "memoize-one": "^4.0.0",
     "prop-types": "^15.5.8",
     "react-draggable": "^3.0.5",

--- a/packages/terra-clinical-data-grid/src/DataGrid.jsx
+++ b/packages/terra-clinical-data-grid/src/DataGrid.jsx
@@ -8,7 +8,7 @@ import ResizeObserver from 'resize-observer-polyfill';
 import ContentContainer from 'terra-content-container';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 
-import * as KeyCode from 'keycode-js';
+import { KEY_SHIFT, KEY_TAB } from 'keycode-js';
 import Cell from './subcomponents/Cell';
 import HeaderCell from './subcomponents/HeaderCell';
 import RowSelectionCell from './subcomponents/RowSelectionCell';
@@ -393,11 +393,11 @@ class DataGrid extends React.Component {
    * Keyboard Events
    */
   handleKeyDown(event) {
-    if (event.keyCode === KeyCode.KEY_SHIFT) {
+    if (event.keyCode === KEY_SHIFT) {
       this.shiftIsPressed = true;
     }
 
-    if (event.keyCode === KeyCode.KEY_TAB) {
+    if (event.keyCode === KEY_TAB) {
       const { activeElement } = document;
 
       if (!activeElement) {
@@ -424,7 +424,7 @@ class DataGrid extends React.Component {
   }
 
   handleKeyUp(event) {
-    if (event.keyCode === KeyCode.KEY_SHIFT) {
+    if (event.keyCode === KEY_SHIFT) {
       this.shiftIsPressed = false;
     }
   }

--- a/packages/terra-clinical-data-grid/src/DataGrid.jsx
+++ b/packages/terra-clinical-data-grid/src/DataGrid.jsx
@@ -8,7 +8,7 @@ import ResizeObserver from 'resize-observer-polyfill';
 import ContentContainer from 'terra-content-container';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import Cell from './subcomponents/Cell';
 import HeaderCell from './subcomponents/HeaderCell';
 import RowSelectionCell from './subcomponents/RowSelectionCell';

--- a/packages/terra-clinical-data-grid/src/subcomponents/Cell.jsx
+++ b/packages/terra-clinical-data-grid/src/subcomponents/Cell.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import classNamesBind from 'classnames/bind';
 import ThemeContext from 'terra-theme-context';
 import memoize from 'memoize-one';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 
 import styles from './Cell.module.scss';
 

--- a/packages/terra-clinical-data-grid/src/subcomponents/Cell.jsx
+++ b/packages/terra-clinical-data-grid/src/subcomponents/Cell.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import classNamesBind from 'classnames/bind';
 import ThemeContext from 'terra-theme-context';
 import memoize from 'memoize-one';
-import * as KeyCode from 'keycode-js';
+import { KEY_RETURN, KEY_SPACE } from 'keycode-js';
 
 import styles from './Cell.module.scss';
 
@@ -75,7 +75,7 @@ class Cell extends React.Component {
   }
 
   handleKeyDown(event) {
-    if (event.nativeEvent.keyCode === KeyCode.KEY_RETURN || event.nativeEvent.keyCode === KeyCode.KEY_SPACE) {
+    if (event.nativeEvent.keyCode === KEY_RETURN || event.nativeEvent.keyCode === KEY_SPACE) {
       const { onSelect } = this.props;
 
       if (onSelect) {

--- a/packages/terra-clinical-data-grid/src/subcomponents/SectionHeader.jsx
+++ b/packages/terra-clinical-data-grid/src/subcomponents/SectionHeader.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import IconCaretRight from 'terra-icon/lib/icon/IconCaretRight';
 import IconCaretDown from 'terra-icon/lib/icon/IconCaretDown';
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 import ThemeContext from 'terra-theme-context';
 
 import styles from './SectionHeader.module.scss';

--- a/packages/terra-clinical-data-grid/src/subcomponents/SectionHeader.jsx
+++ b/packages/terra-clinical-data-grid/src/subcomponents/SectionHeader.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import IconCaretRight from 'terra-icon/lib/icon/IconCaretRight';
 import IconCaretDown from 'terra-icon/lib/icon/IconCaretDown';
-import * as KeyCode from 'keycode-js';
+import { KEY_RETURN, KEY_SPACE } from 'keycode-js';
 import ThemeContext from 'terra-theme-context';
 
 import styles from './SectionHeader.module.scss';
@@ -68,7 +68,7 @@ class SectionHeader extends React.Component {
   }
 
   handleKeyDown(event) {
-    if (event.nativeEvent.keyCode === KeyCode.KEY_RETURN || event.nativeEvent.keyCode === KeyCode.KEY_SPACE) {
+    if (event.nativeEvent.keyCode === KEY_RETURN || event.nativeEvent.keyCode === KEY_SPACE) {
       const { onRequestSectionCollapse, sectionId } = this.props;
 
       if (onRequestSectionCollapse) {

--- a/packages/terra-clinical-item-collection/CHANGELOG.md
+++ b/packages/terra-clinical-item-collection/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Fixed
  * Fixed broken links in documentation.
 
+* Changed
+ * Updated the 'keycode-js' version from '^1.0.4' to '^2.0.1'.
+ 
 ## 4.26.0 - (December 8, 2020)
 
 * Changed

--- a/packages/terra-clinical-item-collection/CHANGELOG.md
+++ b/packages/terra-clinical-item-collection/CHANGELOG.md
@@ -6,7 +6,7 @@
  * Fixed broken links in documentation.
 
 * Changed
- * Updated the 'keycode-js' version from '^1.0.4' to '^2.0.1'.
+ * Updated the 'keycode-js' version from '^1.0.4' to '^3.1.0'.
  
 ## 4.26.0 - (December 8, 2020)
 

--- a/packages/terra-clinical-item-collection/package.json
+++ b/packages/terra-clinical-item-collection/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "keycode-js": "^1.0.4",
+    "keycode-js": "^2.0.1",
     "prop-types": "^15.5.8",
     "terra-clinical-item-view": "^3.20.0",
     "terra-icon": "^3.0.0",

--- a/packages/terra-clinical-item-collection/package.json
+++ b/packages/terra-clinical-item-collection/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "keycode-js": "^2.0.1",
+    "keycode-js": "^3.1.0",
     "prop-types": "^15.5.8",
     "terra-clinical-item-view": "^3.20.0",
     "terra-icon": "^3.0.0",

--- a/packages/terra-clinical-item-collection/src/_ItemCollectionUtils.jsx
+++ b/packages/terra-clinical-item-collection/src/_ItemCollectionUtils.jsx
@@ -1,4 +1,4 @@
-import KeyCode from 'keycode-js';
+import * as KeyCode from 'keycode-js';
 /**
  * This function ensures the correct elements are provided to create a consistent item view layout. To handle a
  * potential missing required accessory element, a boolean is provided to indicate if start accessory space is needed.

--- a/packages/terra-clinical-item-collection/src/_ItemCollectionUtils.jsx
+++ b/packages/terra-clinical-item-collection/src/_ItemCollectionUtils.jsx
@@ -1,4 +1,4 @@
-import * as KeyCode from 'keycode-js';
+import { KEY_RETURN, KEY_SPACE } from 'keycode-js';
 /**
  * This function ensures the correct elements are provided to create a consistent item view layout. To handle a
  * potential missing required accessory element, a boolean is provided to indicate if start accessory space is needed.
@@ -98,7 +98,7 @@ function createOnSelectProps(onSelect, key) {
   };
 
   selectableProps.onKeyDown = (event) => {
-    if (event.nativeEvent.keyCode === KeyCode.KEY_RETURN || event.nativeEvent.keyCode === KeyCode.KEY_SPACE) {
+    if (event.nativeEvent.keyCode === KEY_RETURN || event.nativeEvent.keyCode === KEY_SPACE) {
       onSelect(event, key);
     }
   };


### PR DESCRIPTION
### Summary
The open issue #656 identified an older version (v1) of keycode-js still being used in terra-clinical-data-grid. I saw the same older version being used in terra-clinical-item-collection so I updated that to version 2 as well.

<!--- Include any issue addressed by this pull request. -->
Closes #656

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-clinical-deployed-pr-45.herokuapp.com/ -->
https://terra-clinical-deployed-pr-#.herokuapp.com/

### Testing
Ran Jest tests and WDIO tests locally for terra-clinical-data-grid and terra-clinical-item-collection. None of the snapshots or screenshots needed to be updated.



Thank you for contributing to Terra.
@cerner/terra
