### PR TITLE
[terra-clinical]Fix scss lint failing due to latest version of postcss 

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "jest": "^26.6.3",
     "lerna": "^3.20.2",
     "link-parent-bin": "^1.0.0",
-    "postcss": "^8.2.2",
+    "postcss": "8.3.11",
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
     "react-intl": "^2.9.0",


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Downgraded postcss to 8.3.11 as css linter is failing for postcss version 8.4 and above.
<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-clinical-deployed-pr-45.herokuapp.com/ -->
https://terra-clinical-deployed-pr-#.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
