### PR TITLE
[terra-clinical-data-grid] Decorative row error

### DIFF
--- a/packages/terra-clinical-data-grid/CHANGELOG.md
+++ b/packages/terra-clinical-data-grid/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.35.2 - (April 20, 2022)
+
 * Fixed
   * Fixed `Cannot read property 'id' of undefined` error in `getFirstAndLastVisibleRowData` when all rows are set `isDecorative`.
 

--- a/packages/terra-clinical-data-grid/CHANGELOG.md
+++ b/packages/terra-clinical-data-grid/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed `Cannot read property 'id' of undefined` error in `getFirstAndLastVisibleRowData` when all rows are set `isDecorative`.
+
 ## 2.35.1 - (April 19, 2022)
 
 * Changed

--- a/packages/terra-clinical-data-grid/package.json
+++ b/packages/terra-clinical-data-grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-clinical-data-grid",
   "main": "lib/DataGrid.js",
-  "version": "2.35.1",
+  "version": "2.35.2",
   "description": "An organizational component that renders a collection of data in a grid-like format.",
   "repository": {
     "type": "git",

--- a/packages/terra-clinical-data-grid/src/utils/dataGridUtils.js
+++ b/packages/terra-clinical-data-grid/src/utils/dataGridUtils.js
@@ -116,11 +116,20 @@ const getFirstAndLastVisibleRowData = (sections) => {
     return rowData;
   }
 
-  rowData.firstRowSectionId = visibleSections.find(section => {
+  const firstVisibleRow = visibleSections.find(section => {
     const { rows } = section;
-    rowData.firstRowId = rows.find(row => !row.isDecorative).id;
+    const firstRow = rows.find(row => !row.isDecorative);
+
+    if (firstRow) {
+      rowData.firstRowId = firstRow.id;
+    }
+
     return !!rowData.firstRowId;
-  }).id;
+  });
+
+  if (firstVisibleRow) {
+    rowData.firstRowSectionId = firstVisibleRow.id;
+  }
 
   if (!rowData.firstRowId) {
     /**

--- a/packages/terra-clinical-data-grid/tests/jest/utils/dataGridUtils.test.js
+++ b/packages/terra-clinical-data-grid/tests/jest/utils/dataGridUtils.test.js
@@ -4,6 +4,7 @@ const {
   VOID_COLUMN,
   ROW_SELECTION_COLUMN,
   getAccessibleContents,
+  getFirstAndLastVisibleRowData,
   getWidthForColumn,
   getTotalColumnWidth,
   getPinnedColumns,
@@ -209,5 +210,97 @@ describe('matchesSelector', () => {
     expect(matchesSelector(element, '.test-class')).toBe(true);
 
     Element.prototype.msMatchesSelector = undefined;
+  });
+});
+
+describe('getFirstAndLastVisibleRowData', () => {
+  it('should return row data with no decorative rows', () => {
+    const expectedRowData = {
+      firstRowSectionId: 'Section-0',
+      firstRowId: 'Section-0-Row-0',
+      lastRowSectionId: 'Section-1',
+      lastRowId: 'Section-1-Row-1',
+    };
+    const sections = [
+      {
+        id: 'Section-0',
+        isCollapsed: false,
+        rows: [
+          {
+            id: 'Section-0-Row-0',
+          },
+          {
+            id: 'Section-0-Row-1',
+          },
+        ],
+      },
+      {
+        id: 'Section-1',
+        isCollapsed: false,
+        rows: [
+          {
+            id: 'Section-1-Row-0',
+          },
+          {
+            id: 'Section-1-Row-1',
+          },
+        ],
+      },
+    ];
+
+    expect(getFirstAndLastVisibleRowData(sections)).toEqual(expectedRowData);
+  });
+
+  it('should return row data when there is a decorative row', () => {
+    const expectedRowData = {
+      firstRowSectionId: 'Section-0',
+      firstRowId: 'Row-1',
+      lastRowSectionId: 'Section-0',
+      lastRowId: 'Row-1',
+    };
+    const sections = [
+      {
+        id: 'Section-0',
+        isCollapsed: false,
+        rows: [
+          {
+            id: 'Row-0',
+            isDecorative: true,
+          },
+          {
+            id: 'Row-1',
+          },
+        ],
+      },
+    ];
+
+    expect(getFirstAndLastVisibleRowData(sections)).toEqual(expectedRowData);
+  });
+
+  it('should return null row data when all rows are decorative', () => {
+    const expectedRowData = {
+      firstRowSectionId: null,
+      firstRowId: null,
+      lastRowSectionId: null,
+      lastRowId: null,
+    };
+    const sections = [
+      {
+        id: 'Section-0',
+        isCollapsed: false,
+        rows: [
+          {
+            id: 'Row-0',
+            isDecorative: true,
+          },
+          {
+            id: 'Row-1',
+            isDecorative: true,
+          },
+        ],
+      },
+    ];
+
+    expect(getFirstAndLastVisibleRowData(sections)).toEqual(expectedRowData);
   });
 });


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

- This PR also publishes the fix so I don't need to issue a separate release PR.
- Where all rows in all sections are marked as decorative (`isDecorative`), the following error is thrown in `getFirstAndLastVisibleRowData` because no decorative rows are found to access the id.

<img width="1364" alt="Screen Shot 2022-04-20 at 1 38 52 PM" src="https://user-images.githubusercontent.com/22618655/164300057-db5deea3-051a-4369-972d-563494b14697.png">


<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes: UXPLATFORM-6501

### Deployment Link
<!---Include the deployment link, if applicable. -->
<!--- Example: https://terra-clinical-deployed-pr-45.herokuapp.com/ -->
https://terra-clinical-deployed-pr-#.herokuapp.com/

### Testing
This change has been tested by providing a packed .tgz file to the engineer who reported the issue and verified that the error no longer occurs with this change.

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra