### PR TITLE
[terra-clinical-item-display] Add accessibility guidance for isTruncated prop

### DIFF
--- a/packages/terra-clinical-item-display/CHANGELOG.md
+++ b/packages/terra-clinical-item-display/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * Added
   * Added `textStyleMeaning` prop to allow defining a meaning for styled text to be read by screen readers.
+  * Added accessibility guidance for using `isTruncated` prop.
 
 ## 4.6.0 - (March 29, 2023)
 

--- a/packages/terra-clinical-item-display/package.json
+++ b/packages/terra-clinical-item-display/package.json
@@ -31,8 +31,13 @@
     "@cerner/terra-docs": "^1.9.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
+    "terra-action-header": "^2.78.0",
     "terra-button": "^3.65.0",
+    "terra-content-container": "^3.38.0",
+    "terra-disclosure-manager": "^4.42.0",
     "terra-icon": "^3.0.0",
+    "terra-list": "^4.57.0",
+    "terra-slide-panel-manager": "^5.69.0",
     "terra-theme-context": "^1.0.0"
   },
   "scripts": {

--- a/packages/terra-clinical-item-display/package.json
+++ b/packages/terra-clinical-item-display/package.json
@@ -31,13 +31,8 @@
     "@cerner/terra-docs": "^1.9.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-action-header": "^2.78.0",
     "terra-button": "^3.65.0",
-    "terra-content-container": "^3.38.0",
-    "terra-disclosure-manager": "^4.42.0",
     "terra-icon": "^3.0.0",
-    "terra-list": "^4.57.0",
-    "terra-slide-panel-manager": "^5.69.0",
     "terra-theme-context": "^1.0.0"
   },
   "scripts": {

--- a/packages/terra-clinical-item-display/package.json
+++ b/packages/terra-clinical-item-display/package.json
@@ -28,6 +28,7 @@
     "react-intl": ">=2.8.0, <6.0.0"
   },
   "dependencies": {
+    "@cerner/terra-docs": "^1.9.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
     "terra-icon": "^3.0.0",

--- a/packages/terra-clinical-item-display/package.json
+++ b/packages/terra-clinical-item-display/package.json
@@ -34,10 +34,8 @@
     "terra-action-header": "^2.78.0",
     "terra-button": "^3.65.0",
     "terra-content-container": "^3.38.0",
-    "terra-disclosure-manager": "^4.42.0",
     "terra-icon": "^3.0.0",
     "terra-list": "^4.57.0",
-    "terra-slide-panel-manager": "^5.69.0",
     "terra-theme-context": "^1.0.0"
   },
   "scripts": {

--- a/packages/terra-clinical-item-display/package.json
+++ b/packages/terra-clinical-item-display/package.json
@@ -31,6 +31,7 @@
     "@cerner/terra-docs": "^1.9.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
+    "terra-button": "^3.65.0",
     "terra-icon": "^3.0.0",
     "terra-theme-context": "^1.0.0"
   },

--- a/packages/terra-clinical-item-display/package.json
+++ b/packages/terra-clinical-item-display/package.json
@@ -32,10 +32,10 @@
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
     "terra-action-header": "^2.78.0",
-    "terra-button": "^3.65.0",
     "terra-content-container": "^3.38.0",
     "terra-icon": "^3.0.0",
     "terra-list": "^4.57.0",
+    "terra-show-hide": "^2.60.0",
     "terra-theme-context": "^1.0.0"
   },
   "scripts": {

--- a/packages/terra-clinical-item-display/src/ItemComment.jsx
+++ b/packages/terra-clinical-item-display/src/ItemComment.jsx
@@ -16,7 +16,7 @@ const propTypes = {
   text: PropTypes.string,
   /**
    * Whether or not the text should be truncated in display. Note: To ensure keyboard accessibility,
-   * if this prop is used, consumers will need to provide a pattern to disclose the rest of the text
+   * if this prop is used, consumers will need to provide a method to disclose the rest of the text
    * so that it is accessible to keyboard users.
    */
   isTruncated: PropTypes.bool,

--- a/packages/terra-clinical-item-display/src/ItemComment.jsx
+++ b/packages/terra-clinical-item-display/src/ItemComment.jsx
@@ -15,7 +15,9 @@ const propTypes = {
    */
   text: PropTypes.string,
   /**
-   * Whether or not the text should be truncated in display.
+   * Whether or not the text should be truncated in display. Note: To ensure keyboard accessibility,
+   * if this prop is used, consumers will need to provide a pattern to disclose the rest of the text
+   * so that it is accessible to keyboard users.
    */
   isTruncated: PropTypes.bool,
 };

--- a/packages/terra-clinical-item-display/src/ItemDisplay.jsx
+++ b/packages/terra-clinical-item-display/src/ItemDisplay.jsx
@@ -27,7 +27,9 @@ const propTypes = {
    */
   textStyle: PropTypes.oneOf(Object.values(TextStyles)),
   /**
-   * Whether or not the text should be truncated.
+   * Whether or not the text should be truncated. Note: To ensure keyboard accessibility, if this prop
+   * is used, consumers will need to provide a pattern to disclose the rest of the text so that it is
+   * accessible to keyboard users.
    */
   isTruncated: PropTypes.bool,
   //  TODO: remove isDisabled in the next major release.

--- a/packages/terra-clinical-item-display/src/ItemDisplay.jsx
+++ b/packages/terra-clinical-item-display/src/ItemDisplay.jsx
@@ -28,7 +28,7 @@ const propTypes = {
   textStyle: PropTypes.oneOf(Object.values(TextStyles)),
   /**
    * Whether or not the text should be truncated. Note: To ensure keyboard accessibility, if this prop
-   * is used, consumers will need to provide a pattern to disclose the rest of the text so that it is
+   * is used, consumers will need to provide a method to disclose the rest of the text so that it is
    * accessible to keyboard users.
    */
   isTruncated: PropTypes.bool,

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
@@ -63,7 +63,7 @@ in order to ensure that it is accessible for keyboard navigation users.
 
 </Notice>
 
-<TruncatedText title="Item Display: Truncated Text" />
+<TruncatedText title="Item Display: Truncated Text with Show/Hide Button" />
 
 ## Item Display Props Table 
 <ItemDisplayPropsTable />

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
@@ -42,6 +42,34 @@ This component requires the following peer dependencies be installed in your app
 import ItemDisplay from 'terra-clinical-item-display';
 ```
 
+## Accessibility
+
+<Notice variant="important" ariaLevel="3">
+
+#### Accessibility Guidance: Truncated Text
+
+Truncation of text can pose an accessibility concern if no method of disclosing the full text is available
+to the user. When using `isTruncated`, consumers are responsible for providing a progressive disclosure pattern
+ to disclose the full Item Display text in order to ensure that it is accessible for keyboard navigation users.
+
+**There should always be a method of accessing the truncated information. If there is no way to progressively
+diclose the full content of the truncated information, then truncation should not be used.**
+
+Some examples of progressive disclosure patterns that may be used to disclose truncated information include:
+- Accordions
+- Dialogs
+- Popovers
+- Show/Hide
+- Split Views
+- Toasts
+
+The method of disclosure **must** be accessible via keyboard interactions.
+
+Truncation should be avoided where it is not necessary. Certain content should **never** be truncated (i.e. 
+medication names and dosages in menus where  the user is selecting from a  list of choices).
+
+</Notice>
+
 ## Component Features
 * [Cross-Browser Support](https://engineering.cerner.com/terra-ui/about/terra-ui/component-standards#cross-browser-support)
 * [Responsive Support](https://engineering.cerner.com/terra-ui/about/terra-ui/component-standards#responsive-support)
@@ -53,16 +81,6 @@ import ItemDisplay from 'terra-clinical-item-display';
 <IconText title="Item Display: Icon and Text" />
 <DefaultComment title="Comment Item Display" />
 <TextStyleMeaning title="Item Display: Text Style Meaning for Assistive Technology" />
-
-<Notice variant="important" ariaLevel="3">
-
-#### Accessibility Guidance: Truncated Text
-
-When using `isTruncated`, consumers are responsible for providing a method to disclose the full Item Display text
-in order to ensure that it is accessible for keyboard navigation users.
-
-</Notice>
-
 <TruncatedText title="Item Display: Truncated Text with Show/Hide Button" />
 
 ## Item Display Props Table 

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
@@ -58,7 +58,7 @@ import ItemDisplay from 'terra-clinical-item-display';
 
 #### Accessibility Guidance: Truncated Text
 
-When using `isTruncated`, consumers are responsible for providing a pattern to disclose the full Item Display text
+When using `isTruncated`, consumers are responsible for providing a method to disclose the full Item Display text
 in order to ensure that it is accessible for keyboard navigation users.
 
 </Notice>

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
@@ -82,7 +82,7 @@ medication names and dosages in menus where the user is selecting from a list of
 <IconText title="Item Display: Icon and Text" />
 <DefaultComment title="Comment Item Display" />
 <TextStyleMeaning title="Item Display: Text Style Meaning for Assistive Technology" />
-<TruncatedText title="Item Display: Truncated Text with Show/Hide Button" />
+<TruncatedText title="Item Display: Truncated Text with Show/Hide" />
 <TruncatedTextSlidePanel title="Item Display: Truncated Text with Slide Panel Disclosure" />
 
 ## Item Display Props Table 

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
@@ -54,7 +54,7 @@ to the user. When using `isTruncated`, consumers are responsible for providing a
  to disclose the full Item Display text in order to ensure that it is accessible for keyboard navigation users.
 
 **There should always be a method of accessing the truncated information. If there is no way to progressively
-diclose the full content of the truncated information, then truncation should not be used.**
+disclose the full content of the truncated information, then truncation should not be used.**
 
 Some examples of progressive disclosure patterns that may be used to disclose truncated information include:
 - Accordions

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
@@ -1,4 +1,5 @@
 import { Badge } from 'terra-clinical-item-display/package.json?dev-site-package';
+import { Notice } from "@cerner/terra-docs";
 
 import ItemDisplayPropsTable from 'terra-clinical-item-display/src/ItemDisplay?dev-site-props-table';
 import CommentPropsTable from 'terra-clinical-item-display/src/ItemComment?dev-site-props-table';
@@ -9,6 +10,7 @@ import Icon from '../example/Icon?dev-site-example';
 import IconText from '../example/IconText?dev-site-example';
 import DefaultComment from '../example/DefaultComment?dev-site-example';
 import TextStyleMeaning from '../example/TextStyleMeaning?dev-site-example';
+import TruncatedText from '../example/TruncatedText?dev-site-example';
 
 <Badge />
 
@@ -51,6 +53,17 @@ import ItemDisplay from 'terra-clinical-item-display';
 <IconText title="Item Display: Icon and Text" />
 <DefaultComment title="Comment Item Display" />
 <TextStyleMeaning title="Item Display: Text Style Meaning for Assistive Technology" />
+
+<Notice variant="important" ariaLevel="3">
+
+#### Accessibility Guidance: Truncated Text
+
+When using `isTruncated`, consumers are responsible for providing a pattern to disclose the full Item Display text
+in order to ensure that it is accessible for keyboard navigation users.
+
+</Notice>
+
+<TruncatedText title="Item Display: Truncated Text" />
 
 ## Item Display Props Table 
 <ItemDisplayPropsTable />

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
@@ -11,6 +11,7 @@ import IconText from '../example/IconText?dev-site-example';
 import DefaultComment from '../example/DefaultComment?dev-site-example';
 import TextStyleMeaning from '../example/TextStyleMeaning?dev-site-example';
 import TruncatedText from '../example/TruncatedText?dev-site-example';
+import TruncatedTextSlidePanel from '../example/TruncatedTextSlidePanel?dev-site-example';
 
 <Badge />
 
@@ -82,6 +83,7 @@ medication names and dosages in menus where  the user is selecting from a  list 
 <DefaultComment title="Comment Item Display" />
 <TextStyleMeaning title="Item Display: Text Style Meaning for Assistive Technology" />
 <TruncatedText title="Item Display: Truncated Text with Show/Hide Button" />
+<TruncatedTextSlidePanel title="Item Display: Truncated Text with Slide Panel Disclosure" />
 
 ## Item Display Props Table 
 <ItemDisplayPropsTable />

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/clinical-item-display/clinicalItemDisplay.1.doc.mdx
@@ -67,7 +67,7 @@ Some examples of progressive disclosure patterns that may be used to disclose tr
 The method of disclosure **must** be accessible via keyboard interactions.
 
 Truncation should be avoided where it is not necessary. Certain content should **never** be truncated (i.e. 
-medication names and dosages in menus where  the user is selecting from a  list of choices).
+medication names and dosages in menus where the user is selecting from a list of choices).
 
 </Notice>
 

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedText.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedText.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ItemDisplay from 'terra-clinical-item-display';
+
+const sampleText = 'Mr. James is currently receiving outpatient treatment. He has been diagnosed with an Axis I diagnosis of Psychosis NOS, ruled out Schizoaffective Disorder and Post Traumatic Stress Disorder, and is being treated with Haldol 5mg and Cogentin 1mg.';
+
+const TruncatedTextExample = () => (
+  <ItemDisplay text={sampleText} isTruncated />
+);
+
+export default TruncatedTextExample;

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedText.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedText.jsx
@@ -1,21 +1,21 @@
 import React, { useState } from 'react';
 import ItemDisplay from 'terra-clinical-item-display';
-import Button from 'terra-button';
+import ShowHide from 'terra-show-hide';
 
 const sampleText = 'Mr. James is currently receiving outpatient treatment. He has been diagnosed with an Axis I diagnosis of Psychosis NOS, ruled out Schizoaffective Disorder and Post Traumatic Stress Disorder, and is being treated with Haldol 5mg and Cogentin 1mg.';
 
 const TruncatedTextExample = () => {
-  const [truncated, setTruncated] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
 
-  const handleClick = () => {
-    setTruncated(!truncated);
+  const handleChange = () => {
+    setIsOpen(!isOpen);
   };
 
   return (
     <>
-      <ItemDisplay text={sampleText} isTruncated={truncated} />
-      <br />
-      <Button text="Show/Hide" onClick={handleClick} />
+      <ShowHide preview={<ItemDisplay text={sampleText} isTruncated />} isOpen={isOpen} onChange={handleChange}>
+        {sampleText}
+      </ShowHide>
     </>
   );
 };

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedText.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedText.jsx
@@ -9,12 +9,12 @@ const TruncatedTextExample = () => {
 
   const handleClick = () => {
     setTruncated(!truncated);
-  }
+  };
 
-  return(
+  return (
     <>
       <ItemDisplay text={sampleText} isTruncated={truncated} />
-      <br/>
+      <br />
       <Button text="Show/Hide" onClick={handleClick} />
     </>
   );

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedText.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedText.jsx
@@ -1,10 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ItemDisplay from 'terra-clinical-item-display';
+import Button from 'terra-button';
 
 const sampleText = 'Mr. James is currently receiving outpatient treatment. He has been diagnosed with an Axis I diagnosis of Psychosis NOS, ruled out Schizoaffective Disorder and Post Traumatic Stress Disorder, and is being treated with Haldol 5mg and Cogentin 1mg.';
 
-const TruncatedTextExample = () => (
-  <ItemDisplay text={sampleText} isTruncated />
-);
+const TruncatedTextExample = () => {
+  const [truncated, setTruncated] = useState(true);
+
+  const handleClick = () => {
+    setTruncated(!truncated);
+  }
+
+  return(
+    <>
+      <ItemDisplay text={sampleText} isTruncated={truncated} />
+      <br/>
+      <Button text="Show/Hide" onClick={handleClick} />
+    </>
+  );
+};
 
 export default TruncatedTextExample;

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedTextSlidePanel.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedTextSlidePanel.jsx
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react';
 import ActionHeader from 'terra-action-header/lib/ActionHeader';
 import ContentContainer from 'terra-content-container/lib/ContentContainer';
-import { DisclosureManagerContext, DisclosureManagerHeaderAdapter } from 'terra-disclosure-manager';
+import { DisclosureManagerContext, DisclosureManagerHeaderAdapter } from 'terra-application/lib/disclosure-manager';
 import List, { Item } from 'terra-list/lib/index';
-import SlidePanelManager from 'terra-slide-panel-manager';
+import SlidePanelManager from 'terra-application/lib/slide-panel-manager';
 import ItemDisplay from 'terra-clinical-item-display';
 import PropTypes from 'prop-types';
 

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedTextSlidePanel.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedTextSlidePanel.jsx
@@ -62,7 +62,7 @@ const ContentComponent = () => {
                 content: {
                   key: details.key,
                   component: (
-                    <DisclosureComponent text={details.text}/>
+                    <DisclosureComponent text={details.text} />
                   ),
                 },
               });

--- a/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedTextSlidePanel.jsx
+++ b/packages/terra-clinical-item-display/src/terra-dev-site/doc/example/TruncatedTextSlidePanel.jsx
@@ -1,0 +1,85 @@
+import React, { useContext } from 'react';
+import ActionHeader from 'terra-action-header/lib/ActionHeader';
+import ContentContainer from 'terra-content-container/lib/ContentContainer';
+import { DisclosureManagerContext, DisclosureManagerHeaderAdapter } from 'terra-disclosure-manager';
+import List, { Item } from 'terra-list/lib/index';
+import SlidePanelManager from 'terra-slide-panel-manager';
+import ItemDisplay from 'terra-clinical-item-display';
+import PropTypes from 'prop-types';
+
+const patientDetails = [
+  {
+    key: 'mr-james-1',
+    text: 'Mr. James is currently receiving outpatient treatment. He has been diagnosed with an Axis I diagnosis of Psychosis NOS, ruled out Schizoaffective Disorder and Post Traumatic Stress Disorder, and is being treated with Haldol 5mg and Cogentin 1mg.',
+  },
+  {
+    key: 'mr-smith-2',
+    text: 'Mr. Smith is currently receiving outpatient treatment. He has been diagnosed with an Axis I diagnosis of Psychosis NOS, ruled out Schizoaffective Disorder and Post Traumatic Stress Disorder, and is being treated with Haldol 5mg and Cogentin 1mg.',
+  },
+  {
+    key: 'mr-jones-3',
+    text: 'Mr. Jones is currently receiving outpatient treatment. He has been diagnosed with an Axis I diagnosis of Psychosis NOS, ruled out Schizoaffective Disorder and Post Traumatic Stress Disorder, and is being treated with Haldol 5mg and Cogentin 1mg.',
+  },
+];
+
+const mainHeader = (
+  <ActionHeader text="Patient Details" />
+);
+
+function DisclosureComponent({ text }) {
+  return (
+    <ContentContainer fill>
+      <DisclosureManagerHeaderAdapter title="Patient Details" />
+      <div>
+        <p>{text}</p>
+      </div>
+    </ContentContainer>
+  );
+}
+
+DisclosureComponent.propTypes = {
+  text: PropTypes.string,
+};
+
+const ContentComponent = () => {
+  const disclosureManager = useContext(DisclosureManagerContext);
+  return (
+    <ContentContainer header={mainHeader}>
+      <p id="list-title">Select an item from the list to view its full contents:</p>
+      <List
+        ariaDescription="Select an item from the list to view its full contents."
+        role="listbox"
+      >
+        {patientDetails.map((details) => (
+          <Item
+            key={details.key}
+            isSelectable
+            hasChevron
+            onSelect={() => {
+              disclosureManager.disclose({
+                preferredType: 'panel',
+                size: 'small',
+                content: {
+                  key: details.key,
+                  component: (
+                    <DisclosureComponent text={details.text}/>
+                  ),
+                },
+              });
+            }}
+          >
+            <p><ItemDisplay text={details.text} isTruncated /></p>
+          </Item>
+        ))}
+      </List>
+    </ContentContainer>
+  );
+};
+
+export default function TruncatedTextSlidePanelExample() {
+  return (
+    <SlidePanelManager mainAriaLabel="Patient details">
+      <ContentComponent />
+    </SlidePanelManager>
+  );
+}


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This change adds accessibility guidance in the `terra-clinical-item-display` documentation so that consumers are informed of requirements for ensuring accessibility when using the `isTruncated` prop.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [x] No tests are needed

This PR only includes documentation updates, so no tests are needed.

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-8574 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
