### PR TITLE
[terra-clinical-detail-view] Allow users to select a heading level for title elements

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,6 +40,7 @@ Cerner Corporation
 - Dianna McGinn [@DMcginn]
 - Ashish kumbhare [@ashishkcerner]
 - Razvan Luca [@razvanluca]
+- Vinay Bhargav Arni Ragunathan [@vinaybhargavar]
 
 Community
 
@@ -85,3 +86,4 @@ Community
 [@DMcginn]: https://github.com/DMcginn
 [@ashishkcerner]: https://github.com/ashishkcerner
 [@razvanluca] https://github.com/razvanluca
+[@vinaybhargavar]: https://github.com/vinaybhargavar

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,5 +85,5 @@ Community
 [@saket2403]: https://github.com/saket2403
 [@DMcginn]: https://github.com/DMcginn
 [@ashishkcerner]: https://github.com/ashishkcerner
-[@razvanluca] https://github.com/razvanluca
+[@razvanluca]: https://github.com/razvanluca
 [@vinaybhargavar]: https://github.com/vinaybhargavar

--- a/packages/terra-clinical-detail-view/CHANGELOG.md
+++ b/packages/terra-clinical-detail-view/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Changed
-  * Added `level` prop to allow users to render different heading levels.
+  * Added `level` prop to the DetailView component to allow users to render different heading levels.
 
 ## 3.29.0 - (April 21, 2023)
 

--- a/packages/terra-clinical-detail-view/CHANGELOG.md
+++ b/packages/terra-clinical-detail-view/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Changed
   * Updated the component examples.
-  * Allow users to select a heading level for title elements
+  * Added `level` prop to allow users to render different heading levels.
 
 ## 3.28.0 - (March 29, 2023)
 

--- a/packages/terra-clinical-detail-view/CHANGELOG.md
+++ b/packages/terra-clinical-detail-view/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Changed
   * Updated the component examples.
+  * Allow users to select a heading level for title elements
 
 ## 3.28.0 - (March 29, 2023)
 

--- a/packages/terra-clinical-detail-view/CHANGELOG.md
+++ b/packages/terra-clinical-detail-view/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
 ## Unreleased
+* Changed
+  * Added `level` prop to allow users to render different heading levels.
 
 ## 3.29.0 - (April 21, 2023)
 
 * Changed
   * Updated the component examples.
-  * Added `level` prop to allow users to render different heading levels.
 
 ## 3.28.0 - (March 29, 2023)
 

--- a/packages/terra-clinical-detail-view/CHANGELOG.md
+++ b/packages/terra-clinical-detail-view/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Changed
+* Added
   * Added `level` prop to the DetailView component to allow users to render different heading levels.
 
 ## 3.29.0 - (April 21, 2023)

--- a/packages/terra-clinical-detail-view/CHANGELOG.md
+++ b/packages/terra-clinical-detail-view/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+
 * Changed
   * Added `level` prop to allow users to render different heading levels.
 

--- a/packages/terra-clinical-detail-view/src/DetailList.jsx
+++ b/packages/terra-clinical-detail-view/src/DetailList.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from './DetailList.module.scss';
 import DetailListItem from './DetailListItem';
-import { LevelContext } from './LevelContext';
+import { HeadingLevelContext } from './HeadingLevelContext';
 
 const cx = classNames.bind(styles);
 
@@ -30,7 +30,7 @@ const defaultProps = {
 
 const DetailList = ({ title, children, ...customProps }) => {
   let titleContent;
-  const level = useContext(LevelContext);
+  const level = useContext(HeadingLevelContext);
   const HeaderLevel = `h${level}`;
   if (title) {
     titleContent = (<HeaderLevel className={cx('title')}>{title}</HeaderLevel>);

--- a/packages/terra-clinical-detail-view/src/DetailList.jsx
+++ b/packages/terra-clinical-detail-view/src/DetailList.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from './DetailList.module.scss';
 import DetailListItem from './DetailListItem';
+import { LevelContext } from './LevelContext';
 
 const cx = classNames.bind(styles);
 
@@ -29,8 +30,10 @@ const defaultProps = {
 
 const DetailList = ({ title, children, ...customProps }) => {
   let titleContent;
+  const level = useContext(LevelContext);
+  const HeaderLevel = `h${level}`;
   if (title) {
-    titleContent = (<div className={cx('title')}>{title}</div>);
+    titleContent = (<HeaderLevel className={cx('title')}>{title}</HeaderLevel>);
   }
 
   return (

--- a/packages/terra-clinical-detail-view/src/DetailList.module.scss
+++ b/packages/terra-clinical-detail-view/src/DetailList.module.scss
@@ -1,7 +1,12 @@
 :local {
   .title {
     font-size: 1.1428571429rem;
+    font-weight: normal;
     line-height: 1.4285714286;
+    margin-block-end: auto;
+    margin-block-start: auto;
+    margin-inline-end: auto;
+    margin-inline-start: auto;
     padding-bottom: 0.3571428571rem;
     padding-top: 0.7142857143rem;
   }

--- a/packages/terra-clinical-detail-view/src/DetailView.jsx
+++ b/packages/terra-clinical-detail-view/src/DetailView.jsx
@@ -12,17 +12,27 @@ const cx = classNamesBind.bind(styles);
 
 const propTypes = {
   /**
-   * The primary title to display.
+   * Sets the text to display for the main heading.
    */
   title: PropTypes.string,
 
   /**
-   * Additional list of title strings to display.
+   * Sets the appropriate heading level of Title on the page.
+   * The Level prop will also set the SecondaryTitles and other heading structures to the appropriate heading level to ensure a hierarchical content structure.
+   *
+   * ![IMPORTANT](https://badgen.net/badge/UX/Accessibility/blue) It is critical to screen reader users that the Level prop be appropriately set to a value that best represents the placement of the main Clinical Detail View heading on the page.
+   * Think about headings as creating the outline of a page. Each heading level should be set to represent that outline structure.
+   * Screen reader users rely on the heading levels to understand the structure of information on the page
+   */
+  level: PropTypes.oneOf([2, 3, 4]),
+
+  /**
+   * Sets the text for black subheadings underneath the Title.
    */
   secondaryTitles: PropTypes.arrayOf(PropTypes.string),
 
   /**
-   * List of subtitle strings.
+   * Sets the text for the gray text underneath the Title and SecondaryTitles.
    */
   subtitles: PropTypes.arrayOf(PropTypes.string),
 
@@ -55,15 +65,6 @@ const propTypes = {
    * Sets title sizes to be smaller than default sizes, good for longer titles like medication names.
    */
   isSmallerTitles: PropTypes.bool,
-
-  /**
-   * Sets the heading level to one of &lt;h2&gt;-&lt;h4&gt;. One of `2`, `3`, `4`. This helps screen readers to announce appropriate heading levels.
-   * Changing `level` will not visually change the style of the content.
-   *
-   * ![IMPORTANT](https://badgen.net/badge/UX/Accessibility/blue) It is required to be set in order for the header text to have proper accessibility.
-   * _Note: If the prop is not set, then level 2 will be used by default. This would result in incorrect context of header in application._
-   */
-  level: PropTypes.oneOf([2, 3, 4]),
 };
 
 const defaultProps = {

--- a/packages/terra-clinical-detail-view/src/DetailView.jsx
+++ b/packages/terra-clinical-detail-view/src/DetailView.jsx
@@ -6,7 +6,7 @@ import ThemeContext from 'terra-theme-context';
 import styles from './DetailView.module.scss';
 import DetailList from './DetailList';
 import DetailListItem from './DetailListItem';
-import { LevelContext } from './LevelContext';
+import { HeadingLevelContext } from './HeadingLevelContext';
 
 const cx = classNamesBind.bind(styles);
 
@@ -103,9 +103,7 @@ const DetailView = (props) => {
     attributes.className,
   );
 
-  function createHeaderLevel(headerLevel) {
-    return `h${headerLevel}`;
-  }
+  const createHeaderLevel = (headerLevel) => `h${headerLevel}`;
 
   let titleElement = null;
   let secondaryTitlesElements = [];
@@ -157,9 +155,9 @@ const DetailView = (props) => {
       {graph && divider}
       {graph}
       {divider}
-      <LevelContext.Provider value={nextLevel}>
+      <HeadingLevelContext.Provider value={nextLevel}>
         {dividedDetails}
-      </LevelContext.Provider>
+      </HeadingLevelContext.Provider>
       {footerElement}
     </div>
   );

--- a/packages/terra-clinical-detail-view/src/DetailView.jsx
+++ b/packages/terra-clinical-detail-view/src/DetailView.jsx
@@ -57,11 +57,11 @@ const propTypes = {
   isSmallerTitles: PropTypes.bool,
 
   /**
-   * Sets the heading level &lt;h2&gt;-&lt;h4&gt;. One of `2`, `3`, `4`. This helps screen readers to announce appropriate heading levels.
+   * Sets the heading level to one of &lt;h2&gt;-&lt;h4&gt;. One of `2`, `3`, `4`. This helps screen readers to announce appropriate heading levels.
    * Changing `level` will not visually change the style of the content.
    *
    * ![IMPORTANT](https://badgen.net/badge/UX/Accessibility/blue) It is required to be set in order for the header text to have proper accessibility.
-   * _Note: if the prop is not set level 2 by default. this would result in incorrect context of header in application._
+   * _Note: If the prop is not set, then level 2 will be used by default. This would result in incorrect context of header in application._
    */
   level: PropTypes.oneOf([2, 3, 4]),
 };

--- a/packages/terra-clinical-detail-view/src/DetailView.jsx
+++ b/packages/terra-clinical-detail-view/src/DetailView.jsx
@@ -57,7 +57,7 @@ const propTypes = {
   isSmallerTitles: PropTypes.bool,
 
   /**
-   * Sets the heading level &lt;h1&gt;-&lt;h6&gt;. One of `1`, `2`, `3`, `4`, `5`, `6`. This helps screen readers to announce appropriate heading levels.
+   * Sets the heading level &lt;h2&gt;-&lt;h4&gt;. One of `2`, `3`, `4`. This helps screen readers to announce appropriate heading levels.
    * Changing `level` will not visually change the style of the content.
    *
    * ![IMPORTANT](https://badgen.net/badge/UX/Accessibility/blue) It is required to be set in order for the header text to have proper accessibility.

--- a/packages/terra-clinical-detail-view/src/DetailView.module.scss
+++ b/packages/terra-clinical-detail-view/src/DetailView.module.scss
@@ -31,7 +31,12 @@
 
   .secondary-text {
     font-size: 1.2857rem;
+    font-weight: normal;
+    margin-block-end: auto;
+    margin-block-start: inherit;
     margin-bottom: 0.7142857143rem;
+    margin-inline-end: auto;
+    margin-inline-start: auto;
     word-wrap: break-word;
 
     ~ .subtitle {

--- a/packages/terra-clinical-detail-view/src/DetailView.module.scss
+++ b/packages/terra-clinical-detail-view/src/DetailView.module.scss
@@ -33,7 +33,7 @@
     font-size: 1.2857rem;
     font-weight: normal;
     margin-block-end: auto;
-    margin-block-start: inherit;
+    margin-block-start: auto;
     margin-bottom: 0.7142857143rem;
     margin-inline-end: auto;
     margin-inline-start: auto;

--- a/packages/terra-clinical-detail-view/src/HeadingLevelContext.jsx
+++ b/packages/terra-clinical-detail-view/src/HeadingLevelContext.jsx
@@ -1,4 +1,4 @@
 import { createContext } from 'react';
 
 // eslint-disable-next-line import/prefer-default-export
-export const LevelContext = createContext(2);
+export const HeadingLevelContext = createContext(2);

--- a/packages/terra-clinical-detail-view/src/LevelContext.jsx
+++ b/packages/terra-clinical-detail-view/src/LevelContext.jsx
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+// eslint-disable-next-line import/prefer-default-export
+export const LevelContext = createContext(2);

--- a/packages/terra-clinical-detail-view/src/terra-dev-site/doc/example/DetailViewDivided.jsx
+++ b/packages/terra-clinical-detail-view/src/terra-dev-site/doc/example/DetailViewDivided.jsx
@@ -20,6 +20,7 @@ const DetailViewDivided = () => (
   <div className={cx('detail-view-divided')}>
     <DetailView
       title="Mother"
+      level={3}
       subtitles={['Martha (58 years)', '[second line for subtitles]']}
       details={[
         (

--- a/packages/terra-clinical-detail-view/src/terra-dev-site/doc/example/DetailViewDividedSmallerTitles.jsx
+++ b/packages/terra-clinical-detail-view/src/terra-dev-site/doc/example/DetailViewDividedSmallerTitles.jsx
@@ -62,6 +62,7 @@ const DetailViewDivided = () => (
   <div className={cx('detail-view-divided')}>
     <DetailView
       title="Multiple Ingredients"
+      level={4}
       secondaryTitles={['M. V. I. Adult 10 mL = 10 mL', 'Sodium bicarbonate 8.4% 50 mL', 'Dextrose 5% in Water 1000 mL']}
       subtitles={['30 mg, Oral, Start Date/Time: 06/28/17 20:00:00 CDT. Stop Date/Time: 06/28/17 20:00:00 CDT']}
       accessory={(

--- a/packages/terra-clinical-detail-view/tests/jest/DetailList.test.jsx
+++ b/packages/terra-clinical-detail-view/tests/jest/DetailList.test.jsx
@@ -42,6 +42,11 @@ it('should set the title text', () => {
   expect(wrapper.find('.title').text()).toEqual('Title');
 });
 
+it('should set the heading level for the title', () => {
+  const wrapper = shallow(defaultVariety);
+  expect(wrapper.html('.title')).toContain('<h2 class="title">Title</h2>');
+});
+
 // Structure Tests
 it('should have the class title when title is provided', () => {
   const wrapper = shallow(defaultVariety);

--- a/packages/terra-clinical-detail-view/tests/jest/DetailView.test.jsx
+++ b/packages/terra-clinical-detail-view/tests/jest/DetailView.test.jsx
@@ -21,6 +21,16 @@ it('should render a title', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it('should set the default heading level of the title to h2', () => {
+  const wrapper = shallow(<DetailView title="Title" />);
+  expect(wrapper.html('.primary-text')).toContain('<h2 class="primary-text">Title</h2>');
+});
+
+it('should set the heading level for the title', () => {
+  const wrapper = shallow(<DetailView level={3} title="Title" />);
+  expect(wrapper.html('.primary-text')).toContain('<h3 class="primary-text">Title</h3>');
+});
+
 it('should render a smaller title', () => {
   const detailView = <DetailView title="Header" isSmallerTitles />;
   const wrapper = render(detailView);
@@ -36,6 +46,18 @@ it('should render secondaryTitles', () => {
   );
   const wrapper = render(detailView);
   expect(wrapper).toMatchSnapshot();
+});
+
+it('should set the appropriate heading level for the secondary titles', () => {
+  const wrapper = shallow(
+    <DetailView
+      title="Header"
+      secondaryTitles={['SecondaryTitle1', 'SecondaryTitle2']}
+      level={2}
+    />,
+  );
+  expect(wrapper.html('.secondary-text')).toContain('<h3 class="secondary-text">SecondaryTitle1</h3>');
+  expect(wrapper.html('.secondary-text')).toContain('<h3 class="secondary-text">SecondaryTitle2</h3>');
 });
 
 it('should render subtitles', () => {

--- a/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailList.test.jsx.snap
+++ b/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailList.test.jsx.snap
@@ -39,11 +39,11 @@ exports[`should render a title 1`] = `
 <div
   data-terra-clincial-detail-list="true"
 >
-  <div
+  <h2
     class="title"
   >
     Title
-  </div>
+  </h2>
   <div
     class="list"
   />
@@ -54,11 +54,11 @@ exports[`should render a title and a list 1`] = `
 <div
   data-terra-clincial-detail-list="true"
 >
-  <div
+  <h2
     class="title"
   >
     Title
-  </div>
+  </h2>
   <div
     class="list"
   >

--- a/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailView.test.jsx.snap
+++ b/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailView.test.jsx.snap
@@ -10,6 +10,9 @@ exports[`correctly applies the theme context className 1`] = `
   <hr
     className="divider"
   />
+  <ContextProvider
+    value={2}
+  />
 </div>
 `;
 
@@ -33,11 +36,11 @@ exports[`should render a smaller title 1`] = `
   <div
     class="titles-section titles-smaller"
   >
-    <h1
+    <h2
       class="primary-text"
     >
       Header
-    </h1>
+    </h2>
   </div>
   <hr
     class="divider"
@@ -52,11 +55,11 @@ exports[`should render a title 1`] = `
   <div
     class="titles-section"
   >
-    <h1
+    <h2
       class="primary-text"
     >
       Header
-    </h1>
+    </h2>
   </div>
   <hr
     class="divider"
@@ -71,11 +74,11 @@ exports[`should render accessory 1`] = `
   <div
     class="titles-section"
   >
-    <h1
+    <h2
       class="primary-text"
     >
       Header
-    </h1>
+    </h2>
     <div
       class="accessory"
     >
@@ -97,11 +100,11 @@ exports[`should render details 1`] = `
   <div
     class="titles-section"
   >
-    <h1
+    <h2
       class="primary-text"
     >
       Header
-    </h1>
+    </h2>
     <div
       class="subtitle"
     >
@@ -132,11 +135,11 @@ exports[`should render footer 1`] = `
   <div
     class="titles-section"
   >
-    <h1
+    <h2
       class="primary-text"
     >
       Header
-    </h1>
+    </h2>
     <div
       class="subtitle"
     >
@@ -172,11 +175,11 @@ exports[`should render graph 1`] = `
   <div
     class="titles-section"
   >
-    <h1
+    <h2
       class="primary-text"
     >
       Header
-    </h1>
+    </h2>
     <div
       class="subtitle"
     >
@@ -207,21 +210,21 @@ exports[`should render secondaryTitles 1`] = `
   <div
     class="titles-section"
   >
-    <h1
+    <h2
       class="primary-text"
     >
       Header
-    </h1>
-    <div
+    </h2>
+    <h3
       class="secondary-text"
     >
       SecondaryTitle1
-    </div>
-    <div
+    </h3>
+    <h3
       class="secondary-text"
     >
       SecondaryTitle2
-    </div>
+    </h3>
   </div>
   <hr
     class="divider"
@@ -236,11 +239,11 @@ exports[`should render subtitles 1`] = `
   <div
     class="titles-section"
   >
-    <h1
+    <h2
       class="primary-text"
     >
       Header
-    </h1>
+    </h2>
     <div
       class="subtitle"
     >
@@ -265,11 +268,11 @@ exports[`should render without a divider when indicated 1`] = `
   <div
     class="titles-section"
   >
-    <h1
+    <h2
       class="primary-text"
     >
       Header
-    </h1>
+    </h2>
     <div
       class="subtitle"
     >


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
Currently, the larger texts that are acting as a heading are hard coded as an h1 (title of detail view) or built using div (secondary title and title of detail list). This breaks the proper structure of the page and the screen readers cannot properly relate the information.

**What was changed:**

- The main title uses the appropriate heading level that the consumer wants and does not default to H1. If the level is not passed in, the default heading level would be set to H2.
- The secondaryTitles are a level below the main title if both the title and the secondaryTitles are passed in and the detailList title is a level below that.

**Why it was changed:**

- The screen reader calls out the different titles with appropriate heading levels and there is proper structure to the page.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

![Screen Shot 2023-05-30 at 5 39 20 PM](https://github.com/cerner/terra-clinical/assets/55503680/f4c98ac6-88f4-4cb9-b7a5-25e0b8c53a40)

![Screen Shot 2023-05-30 at 5 39 33 PM](https://github.com/cerner/terra-clinical/assets/55503680/2255f932-75c6-4e6a-b106-1558ea0dd370)

![Screen Shot 2023-05-30 at 5 39 41 PM](https://github.com/cerner/terra-clinical/assets/55503680/b2a923b0-c3de-485f-a721-51295e87efdb)


### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9071

---

Thank you for contributing to Terra.
@cerner/terra
