### PR TITLE
[terra-clinical-result] Add contexts for multiple results in Flowshee…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,14 +40,10 @@ Cerner Corporation
 - Dianna McGinn [@DMcginn]
 - Ashish kumbhare [@ashishkcerner]
 - Razvan Luca [@razvanluca]
-<<<<<<< HEAD
 - Reagan Young [@rayguny]
 - Yixuan Chen [@chenyixuan625]
 - Vinay Bhargav Arni Ragunathan [@vinaybhargavar]
 
-=======
-- Yixuan Chen [@chenyixuan625]
->>>>>>> 6a4ed314 (Update change log and contributors)
 
 Community
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,10 +40,14 @@ Cerner Corporation
 - Dianna McGinn [@DMcginn]
 - Ashish kumbhare [@ashishkcerner]
 - Razvan Luca [@razvanluca]
+<<<<<<< HEAD
 - Reagan Young [@rayguny]
 - Yixuan Chen [@chenyixuan625]
 - Vinay Bhargav Arni Ragunathan [@vinaybhargavar]
 
+=======
+- Yixuan Chen [@chenyixuan625]
+>>>>>>> 6a4ed314 (Update change log and contributors)
 
 Community
 

--- a/packages/terra-clinical-result/CHANGELOG.md
+++ b/packages/terra-clinical-result/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Added screen-reader support for clinical-result icons. (Requires Jest test updates on consuming applications)
   * Added screen-reader support for alternative text for when no results are returned.
   * Added screen-reader support for clinical-result FlowsheetResultCell EnteredInError.
+  * Added screen-reader support for clinical-result FlowsheetResultCell with multiple results.
 
 ## 1.16.0 - (March 29, 2023)
 

--- a/packages/terra-clinical-result/package.json
+++ b/packages/terra-clinical-result/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
+    "terra-enzyme-intl": "^3.0.0",
     "terra-icon": "^3.53.0",
     "terra-mixins": "^1.0.0",
     "terra-theme-context": "^1.0.0",

--- a/packages/terra-clinical-result/src/flowsheet-result-cell/FlowsheetResultCell.jsx
+++ b/packages/terra-clinical-result/src/flowsheet-result-cell/FlowsheetResultCell.jsx
@@ -73,18 +73,18 @@ const interpretationsWithIcons = [
   'low',
 ];
 
-const createEndIcons = (hasCommentIcon, hasModifiedIcon, hasUnverifiedIcon, resultKeyID) => {
+const createEndIcons = (hasCommentIcon, hasModifiedIcon, hasUnverifiedIcon, resultKeyID, intl) => {
   if (!hasCommentIcon && !hasModifiedIcon && !hasUnverifiedIcon) {
     return null;
   }
   let iconElements;
   if (hasUnverifiedIcon) {
-    iconElements = <IconUnverified className={cx('icon-unverified')} />;
+    iconElements = <IconUnverified className={cx('icon-unverified')} a11yLabel={intl.formatMessage({ id: 'Terra.clinicalResult.resultUnverified' })} role="img" focusable="true" />;
   } else {
     iconElements = (
       <React.Fragment>
-        {hasCommentIcon ? (<IconComment className={cx('icon-comment')} />) : null}
-        {hasModifiedIcon ? (<IconModified className={cx('icon-modified')} />) : null}
+        {hasCommentIcon ? (<IconComment className={cx('icon-comment')} a11yLabel={intl.formatMessage({ id: 'Terra.clinicalResult.resultComment' })} role="img" focusable="true" />) : null}
+        {hasModifiedIcon ? (<IconModified className={cx('icon-modified')} a11yLabel={intl.formatMessage({ id: 'Terra.clinicalResult.resultModified' })} role="img" focusable="true" />) : null}
       </React.Fragment>
     );
   }
@@ -322,7 +322,7 @@ const createFlowsheetResultCellDisplay = (resultDataSet, hideUnit, numericOverfl
     const additionalResultsStackDisplay = createEndAdditionalResultsStack(displayCount, additionalResultInterpretations, hasAccessoryIcons, resultKeyID, intl);
     compositeCell.push(additionalResultsStackDisplay);
   }
-  const endAccessoryIcons = createEndIcons(firstResultAttributes.comment, firstResultAttributes.modified, firstResultAttributes.unverified, resultKeyID);
+  const endAccessoryIcons = createEndIcons(firstResultAttributes.comment, firstResultAttributes.modified, firstResultAttributes.unverified, resultKeyID, intl);
   compositeCell.push(endAccessoryIcons);
 
   return compositeCell;

--- a/packages/terra-clinical-result/tests/jest/flowsheet-result-cell/FlowsheetResultCell.test.jsx
+++ b/packages/terra-clinical-result/tests/jest/flowsheet-result-cell/FlowsheetResultCell.test.jsx
@@ -226,6 +226,23 @@ describe('FlowsheetResultCell', () => {
     expect(cell).toMatchSnapshot();
   });
 
+  it('should render correctly when a multiple results cell contains icons', () => {
+    const results = [
+      {
+        ...DefaultResult,
+        hasComment: true,
+        interpretation: 'critical',
+      },
+      {
+        ...DefaultResult,
+        isModified: true,
+        interpretation: 'normal',
+      },
+    ];
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} hideUnit />).dive();
+    expect(cell).toMatchSnapshot();
+  });
+
   describe('paddingStyle', () => {
     it('should render when given none', () => {
       const results = [

--- a/packages/terra-clinical-result/tests/jest/flowsheet-result-cell/FlowsheetResultCell.test.jsx
+++ b/packages/terra-clinical-result/tests/jest/flowsheet-result-cell/FlowsheetResultCell.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { shallowWithIntl } from 'terra-enzyme-intl';
 import FlowsheetResultCell from '../../../src/flowsheet-result-cell/FlowsheetResultCell';
 import DefaultResult, {
   DefaultBloodPressureResult, DefaultSystolicResult, DefaultDiastolicResult, DefaultResultWithNoEventId, DefaultBloodPressureDiastolicResultWithNoId, DefaultBloodPressureSystolicResultWithNoId,
@@ -7,17 +8,17 @@ import DefaultResult, {
 // Snapshot Tests
 describe('FlowsheetResultCell', () => {
   it('should render a ResultError if hasResultError is true', () => {
-    const result = shallow(<FlowsheetResultCell hasResultError />);
+    const result = shallowWithIntl(<FlowsheetResultCell hasResultError />).dive();
     expect(result).toMatchSnapshot();
   });
 
   it('should render a NoData if hasResultNoData is true', () => {
-    const result = shallow(<FlowsheetResultCell hasResultNoData />);
+    const result = shallowWithIntl(<FlowsheetResultCell hasResultNoData />).dive();
     expect(result).toMatchSnapshot();
   });
 
   it('should render an error with bad data', () => {
-    const result = shallow(<FlowsheetResultCell />);
+    const result = shallowWithIntl(<FlowsheetResultCell />).dive();
     expect(result).toMatchSnapshot();
   });
 
@@ -26,7 +27,7 @@ describe('FlowsheetResultCell', () => {
       DefaultResult,
       DefaultBloodPressureResult,
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} />).dive();
     expect(cell).toMatchSnapshot();
   });
 
@@ -34,7 +35,7 @@ describe('FlowsheetResultCell', () => {
     const results = [
       DefaultResultWithNoEventId,
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} />).dive();
     expect(cell).toMatchSnapshot();
   });
 
@@ -42,7 +43,7 @@ describe('FlowsheetResultCell', () => {
     const results = [
       DefaultBloodPressureSystolicResultWithNoId,
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} />).dive();
     expect(cell).toMatchSnapshot();
   });
 
@@ -50,12 +51,12 @@ describe('FlowsheetResultCell', () => {
     const results = [
       DefaultBloodPressureDiastolicResultWithNoId,
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} />).dive();
     expect(cell).toMatchSnapshot();
   });
 
   it('should render an error when given no result data', () => {
-    const cell = shallow(<FlowsheetResultCell />);
+    const cell = shallowWithIntl(<FlowsheetResultCell />).dive();
     expect(cell).toMatchSnapshot();
   });
 
@@ -64,7 +65,7 @@ describe('FlowsheetResultCell', () => {
       DefaultResult,
       DefaultBloodPressureResult,
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} hideUnit />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} hideUnit />).dive();
     expect(cell).toMatchSnapshot();
   });
 
@@ -77,7 +78,7 @@ describe('FlowsheetResultCell', () => {
       },
       DefaultResult,
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} hideUnit />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} hideUnit />).dive();
     expect(cell).toMatchSnapshot();
   });
 
@@ -94,7 +95,7 @@ describe('FlowsheetResultCell', () => {
         interpretation: 'critical',
       },
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} hideUnit />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} hideUnit />).dive();
     expect(cell).toMatchSnapshot();
   });
 
@@ -113,7 +114,7 @@ describe('FlowsheetResultCell', () => {
       },
       DefaultBloodPressureResult,
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} hideUnit />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} hideUnit />).dive();
     expect(cell).toMatchSnapshot();
   });
 
@@ -134,7 +135,7 @@ describe('FlowsheetResultCell', () => {
       },
       DefaultBloodPressureResult,
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} hideUnit />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} hideUnit />).dive();
     expect(cell).toMatchSnapshot();
   });
 
@@ -156,7 +157,7 @@ describe('FlowsheetResultCell', () => {
       },
       DefaultBloodPressureResult,
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} hideUnit />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} hideUnit />).dive();
     expect(cell.find('.additional-end-display').hasClass('interpretation-critical')).toBe(false);
   });
 
@@ -189,7 +190,39 @@ describe('FlowsheetResultCell', () => {
         },
       },
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} />).dive();
+    expect(cell).toMatchSnapshot();
+  });
+
+  it('should render correctly with at least 1 critical or out of range result', () => {
+    const results = [
+      {
+        ...DefaultResult,
+        interpretation: 'critical',
+      },
+      {
+        ...DefaultResult,
+        interpretation: 'critical',
+      },
+    ];
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} hideUnit />).dive();
+    expect(cell.find('VisuallyHiddenText').at(0).prop('text')).toEqual('Terra.clinicalResult.multipleResults');
+    expect(cell).toMatchSnapshot();
+  });
+
+  it('should render correctly with all normal results', () => {
+    const results = [
+      {
+        ...DefaultResult,
+        interpretation: 'normal',
+      },
+      {
+        ...DefaultResult,
+        interpretation: 'normal',
+      },
+    ];
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} hideUnit />).dive();
+    expect(cell.find('VisuallyHiddenText').at(0).prop('text')).toEqual('Terra.clinicalResult.multipleNormalResults');
     expect(cell).toMatchSnapshot();
   });
 
@@ -199,7 +232,7 @@ describe('FlowsheetResultCell', () => {
         DefaultResult,
         DefaultBloodPressureResult,
       ];
-      const cell = shallow(<FlowsheetResultCell resultDataSet={results} paddingStyle="none" />);
+      const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} paddingStyle="none" />).dive();
       expect(cell).toMatchSnapshot();
     });
 
@@ -208,7 +241,7 @@ describe('FlowsheetResultCell', () => {
         DefaultResult,
         DefaultBloodPressureResult,
       ];
-      const cell = shallow(<FlowsheetResultCell resultDataSet={results} paddingStyle="standard" />);
+      const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} paddingStyle="standard" />).dive();
       expect(cell).toMatchSnapshot();
     });
 
@@ -217,7 +250,7 @@ describe('FlowsheetResultCell', () => {
         DefaultResult,
         DefaultBloodPressureResult,
       ];
-      const cell = shallow(<FlowsheetResultCell resultDataSet={results} paddingStyle="compact" />);
+      const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} paddingStyle="compact" />).dive();
       expect(cell).toMatchSnapshot();
     });
   });
@@ -231,7 +264,7 @@ describe('FlowsheetResultCell', () => {
       DefaultResult,
       DefaultBloodPressureResult,
     ];
-    const cell = shallow(<FlowsheetResultCell resultDataSet={results} />);
+    const cell = shallowWithIntl(<FlowsheetResultCell resultDataSet={results} />).dive();
     expect(cell).toMatchSnapshot();
   });
 });

--- a/packages/terra-clinical-result/tests/jest/flowsheet-result-cell/__snapshots__/FlowsheetResultCell.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/flowsheet-result-cell/__snapshots__/FlowsheetResultCell.test.jsx.snap
@@ -26,6 +26,7 @@ exports[`FlowsheetResultCell correctly applies the theme context className 1`] =
     key="AdditionalResultsDisplay-111"
   >
     <div
+      aria-hidden="true"
       className="additional-results-stack"
     >
       <span
@@ -39,6 +40,9 @@ exports[`FlowsheetResultCell correctly applies the theme context className 1`] =
         2
       </span>
     </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
   </div>
 </div>
 `;
@@ -69,6 +73,7 @@ exports[`FlowsheetResultCell paddingStyle should render when given compact 1`] =
     key="AdditionalResultsDisplay-111"
   >
     <div
+      aria-hidden="true"
       className="additional-results-stack"
     >
       <span
@@ -82,6 +87,9 @@ exports[`FlowsheetResultCell paddingStyle should render when given compact 1`] =
         2
       </span>
     </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
   </div>
 </div>
 `;
@@ -112,6 +120,7 @@ exports[`FlowsheetResultCell paddingStyle should render when given none 1`] = `
     key="AdditionalResultsDisplay-111"
   >
     <div
+      aria-hidden="true"
       className="additional-results-stack"
     >
       <span
@@ -125,6 +134,9 @@ exports[`FlowsheetResultCell paddingStyle should render when given none 1`] = `
         2
       </span>
     </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
   </div>
 </div>
 `;
@@ -155,6 +167,7 @@ exports[`FlowsheetResultCell paddingStyle should render when given standard 1`] 
     key="AdditionalResultsDisplay-111"
   >
     <div
+      aria-hidden="true"
       className="additional-results-stack"
     >
       <span
@@ -168,6 +181,9 @@ exports[`FlowsheetResultCell paddingStyle should render when given standard 1`] 
         2
       </span>
     </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
   </div>
 </div>
 `;
@@ -199,6 +215,7 @@ exports[`FlowsheetResultCell should pass hideUnit down 1`] = `
     key="AdditionalResultsDisplay-111"
   >
     <div
+      aria-hidden="true"
       className="additional-results-stack"
     >
       <span
@@ -212,6 +229,9 @@ exports[`FlowsheetResultCell should pass hideUnit down 1`] = `
         2
       </span>
     </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
   </div>
 </div>
 `;
@@ -257,6 +277,7 @@ exports[`FlowsheetResultCell should render a entered-in-error status standard re
     key="AdditionalResultsDisplay-111"
   >
     <div
+      aria-hidden="true"
       className="additional-results-stack"
     >
       <span
@@ -270,6 +291,9 @@ exports[`FlowsheetResultCell should render a entered-in-error status standard re
         2
       </span>
     </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
   </div>
 </div>
 `;
@@ -341,6 +365,7 @@ exports[`FlowsheetResultCell should render blood pressure correctly with an inte
     key="AdditionalResultsDisplay-111"
   >
     <div
+      aria-hidden="true"
       className="additional-results-stack"
     >
       <span
@@ -354,6 +379,9 @@ exports[`FlowsheetResultCell should render blood pressure correctly with an inte
         2
       </span>
     </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
   </div>
   <div
     className="end-accessory-icons"
@@ -387,6 +415,7 @@ exports[`FlowsheetResultCell should render both entered-in-error status bloodpre
     key="AdditionalResultsDisplay-111"
   >
     <div
+      aria-hidden="true"
       className="additional-results-stack"
     >
       <span
@@ -400,6 +429,58 @@ exports[`FlowsheetResultCell should render both entered-in-error status bloodpre
         2
       </span>
     </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
+  </div>
+</div>
+`;
+
+exports[`FlowsheetResultCell should render correctly with all normal results 1`] = `
+<div
+  className="flowsheet-result-cell padding-compact"
+>
+  <div
+    className="primary-display"
+    key="ClinicalResultDisplay-111"
+  >
+    <ClinicalResult
+      eventId="111"
+      hideAccessoryDisplays={true}
+      hideUnit={true}
+      interpretation="normal"
+      isTruncated={true}
+      key="ClinicalResult-111"
+      result={
+        Object {
+          "unit": "mL",
+          "value": "12345.678",
+        }
+      }
+    />
+  </div>
+  <div
+    className="additional-end-display no-accessory-icons"
+    key="AdditionalResultsDisplay-111"
+  >
+    <div
+      aria-hidden="true"
+      className="additional-results-stack"
+    >
+      <span
+        className="additional-results-value"
+      >
+        2
+      </span>
+      <span
+        className="additional-results-value"
+      >
+        2
+      </span>
+    </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
   </div>
 </div>
 `;
@@ -433,6 +514,7 @@ exports[`FlowsheetResultCell should render correctly with an interpretation and 
     key="AdditionalResultsDisplay-111"
   >
     <div
+      aria-hidden="true"
       className="additional-results-stack"
     >
       <span
@@ -446,6 +528,9 @@ exports[`FlowsheetResultCell should render correctly with an interpretation and 
         2
       </span>
     </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
   </div>
   <div
     className="end-accessory-icons"
@@ -460,6 +545,55 @@ exports[`FlowsheetResultCell should render correctly with an interpretation and 
         xmlns="http://www.w3.org/2000/svg"
       />
     </div>
+  </div>
+</div>
+`;
+
+exports[`FlowsheetResultCell should render correctly with at least 1 critical or out of range result 1`] = `
+<div
+  className="flowsheet-result-cell padding-compact"
+>
+  <div
+    className="primary-display interpretation"
+    key="ClinicalResultDisplay-111"
+  >
+    <ClinicalResult
+      eventId="111"
+      hideAccessoryDisplays={true}
+      hideUnit={true}
+      interpretation="critical"
+      isTruncated={true}
+      key="ClinicalResult-111"
+      result={
+        Object {
+          "unit": "mL",
+          "value": "12345.678",
+        }
+      }
+    />
+  </div>
+  <div
+    className="additional-end-display no-accessory-icons interpretation-critical"
+    key="AdditionalResultsDisplay-111"
+  >
+    <div
+      aria-hidden="true"
+      className="additional-results-stack"
+    >
+      <span
+        className="additional-results-value"
+      >
+        2
+      </span>
+      <span
+        className="additional-results-value"
+      >
+        2
+      </span>
+    </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleResults"
+    />
   </div>
 </div>
 `;
@@ -479,6 +613,7 @@ exports[`FlowsheetResultCell should render systolic entered-in-error status bloo
     key="AdditionalResultsDisplay-111"
   >
     <div
+      aria-hidden="true"
       className="additional-results-stack"
     >
       <span
@@ -492,6 +627,9 @@ exports[`FlowsheetResultCell should render systolic entered-in-error status bloo
         2
       </span>
     </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
   </div>
 </div>
 `;
@@ -574,6 +712,7 @@ exports[`FlowsheetResultCell should render when given result data 1`] = `
     key="AdditionalResultsDisplay-111"
   >
     <div
+      aria-hidden="true"
       className="additional-results-stack"
     >
       <span
@@ -587,6 +726,9 @@ exports[`FlowsheetResultCell should render when given result data 1`] = `
         2
       </span>
     </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
   </div>
 </div>
 `;

--- a/packages/terra-clinical-result/tests/jest/flowsheet-result-cell/__snapshots__/FlowsheetResultCell.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/flowsheet-result-cell/__snapshots__/FlowsheetResultCell.test.jsx.snap
@@ -391,7 +391,10 @@ exports[`FlowsheetResultCell should render blood pressure correctly with an inte
       className="end-accessory-stack"
     >
       <IconDiamond
+        a11yLabel="Terra.clinicalResult.resultUnverified"
         className="icon-unverified"
+        focusable="true"
+        role="img"
         viewBox="0 0 48 48"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -432,6 +435,75 @@ exports[`FlowsheetResultCell should render both entered-in-error status bloodpre
     <VisuallyHiddenText
       text="Terra.clinicalResult.multipleNormalResults"
     />
+  </div>
+</div>
+`;
+
+exports[`FlowsheetResultCell should render correctly when a multiple results cell contains icons 1`] = `
+<div
+  className="flowsheet-result-cell padding-compact"
+>
+  <div
+    className="primary-display interpretation"
+    key="ClinicalResultDisplay-111"
+  >
+    <ClinicalResult
+      eventId="111"
+      hasComment={true}
+      hideAccessoryDisplays={true}
+      hideUnit={true}
+      interpretation="critical"
+      isTruncated={true}
+      key="ClinicalResult-111"
+      result={
+        Object {
+          "unit": "mL",
+          "value": "12345.678",
+        }
+      }
+    />
+  </div>
+  <div
+    className="additional-end-display"
+    key="AdditionalResultsDisplay-111"
+  >
+    <div
+      aria-hidden="true"
+      className="additional-results-stack"
+    >
+      <span
+        className="additional-results-value"
+      >
+        2
+      </span>
+      <span
+        className="additional-results-value"
+      >
+        2
+      </span>
+    </div>
+    <VisuallyHiddenText
+      text="Terra.clinicalResult.multipleNormalResults"
+    />
+  </div>
+  <div
+    className="end-accessory-icons"
+    key="EndAccessoryIcons-111"
+  >
+    <div
+      className="end-accessory-stack"
+    >
+      <IconComment
+        a11yLabel="Terra.clinicalResult.resultComment"
+        className="icon-comment"
+        data-name="Layer 1"
+        focusable="true"
+        isBidi={true}
+        role="img"
+        viewBox="0 0 48 48"
+        xmlns="http://www.w3.org/2000/svg"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -540,7 +612,10 @@ exports[`FlowsheetResultCell should render correctly with an interpretation and 
       className="end-accessory-stack"
     >
       <IconDiamond
+        a11yLabel="Terra.clinicalResult.resultUnverified"
         className="icon-unverified"
+        focusable="true"
+        role="img"
         viewBox="0 0 48 48"
         xmlns="http://www.w3.org/2000/svg"
       />

--- a/packages/terra-clinical-result/translations/en.json
+++ b/packages/terra-clinical-result/translations/en.json
@@ -10,6 +10,8 @@
   "Terra.clinicalResult.resultModified": "Modified Result",
   "Terra.clinicalResult.resultUnverified": "Unverified Result",
   "Terra.clinicalResult.additionalResults": "{numberOfAdditionalResults} additional results",
+  "Terra.clinicalResult.multipleResults": "A total of {count} results are available with at least 1 {criticality} result.",
+  "Terra.clinicalResult.multipleNormalResults": "A total of {count} results are available.",
   "Terra.clinicalResult.interpretationCritical": "Critical",
   "Terra.clinicalResult.interpretationCriticalHigh": "Critical High",
   "Terra.clinicalResult.interpretationCriticalLow": "Critical Low",


### PR DESCRIPTION
…tResultCell

<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Creating an additional visual hidden text with the constructed string to represent that there are multiple results within this cell.

**Why it was changed:**
The accessibility tooling needs to read out a meaningful string for the FlowsheetResultCell with multiple results in a cell.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
This change was tested using:
Jest, WDIO tests and Screen reader testing

All normal results:
https://github.com/cerner/terra-clinical/assets/44185348/5a80a1a9-8a18-4d67-a490-c2326d2b5329


This change was tested using:

- [x] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9069

---

Thank you for contributing to Terra.
@cerner/terra
