### PR TITLE
[terra-clinical-result] Update Result Time/Name header cells and FlowsheetResultCell to use proper HTML tag

### DIFF
--- a/packages/terra-clinical-result/CHANGELOG.md
+++ b/packages/terra-clinical-result/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Fixed
   * Fixed a check related to Clinical Result strikethrough alt text for if a result unit exists or not.
 
+* Changed
+  * Changed FlowsheetResultCell, ResultNameHeaderCell and ResultTimeHeaderCell in clinical-result to use proper semantic html.
+
 ## 1.17.0 - (June 14, 2023)
 
 * Added
@@ -18,6 +21,7 @@
   * Added screen-reader support for clinical-result FlowsheetResultCell with multiple results.
   * Added screen-reader support for clinical-result ResultNameHeaderCell. Two new optional props are added for providing a full name of the result name and unit respectively.
   * Added screen-reader support for Blood Pressure with additional displays as a group. An additional prop is added for making the blood pressure results a group.
+
 
 ## 1.16.0 - (March 29, 2023)
 

--- a/packages/terra-clinical-result/package.json
+++ b/packages/terra-clinical-result/package.json
@@ -33,6 +33,7 @@
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
     "terra-enzyme-intl": "^3.0.0",
+    "terra-html-table": "^1.16.0",
     "terra-icon": "^3.53.0",
     "terra-mixins": "^1.0.0",
     "terra-theme-context": "^1.0.0",

--- a/packages/terra-clinical-result/src/flowsheet-result-cell/FlowsheetResultCell.module.scss
+++ b/packages/terra-clinical-result/src/flowsheet-result-cell/FlowsheetResultCell.module.scss
@@ -10,13 +10,13 @@
     max-width: 100%;  // Needed for IE10 truncation
     overflow-x: hidden;
     padding: 0;
-    width: 100%;
   }
 
   .primary-display {
     align-items: center;
     display: flex;
     flex: 1 1 100%;
+    float: left;
     height: var(--terra-clinical-result-flowsheet-cell-primary-display-height, 1.78571em); // Must use ems for font scaling
     margin: 0;
     margin-left: var(--terra-clinical-result-flowsheet-cell-interpretation-icon-reserved-space-margin-left, 1.1875em); // Must use ems for font scaling
@@ -33,6 +33,14 @@
     &.error {
       margin-left: 0;
     }
+  }
+
+  .end-display {
+    display: flex;
+    flex: 0 0 auto;
+    float: right;
+    height: var(--terra-clinical-result-flowsheet-cell-end-display-height, 1.78571em); // Must use ems for font scaling
+    min-width: 0;
   }
 
   .additional-end-display {

--- a/packages/terra-clinical-result/src/result-name-header-cell/ResultNameHeaderCell.jsx
+++ b/packages/terra-clinical-result/src/result-name-header-cell/ResultNameHeaderCell.jsx
@@ -99,13 +99,13 @@ const ResultNameHeaderCell = (props) => {
     : <div className={cx('unit')}>{unit}</div>;
 
   return (
-    <div
+    <th
       {...customProps}
       className={nameHeaderCellClassnames}
     >
       {resultNameDisplay}
       {unit && unitDisplay}
-    </div>
+    </th>
   );
 };
 

--- a/packages/terra-clinical-result/src/result-name-header-cell/ResultNameHeaderCell.module.scss
+++ b/packages/terra-clinical-result/src/result-name-header-cell/ResultNameHeaderCell.module.scss
@@ -13,15 +13,21 @@
     .name {
       @include terra-clinical-result-cell-truncate;
       color: var(--terra-clinical-result-name-header-cell-name-color);
+      display: inline;
       flex: 1 1 auto;
       font-size: var(--terra-clinical-result-name-header-cell-name-font-size, 1em); // Must use ems for font scaling
+      font-weight: normal;
       min-width: 10px; // Needed for IE10
+      text-align: left;
     }
 
     .unit {
       color: var(--terra-clinical-result-name-header-cell-unit-color, rgba(28, 31, 33, 0.65));
+      display: inline;
       flex: 0 0 auto;
+      float: right;
       font-size: var(--terra-clinical-result-name-header-cell-unit-font-size, 0.875em); // Must use ems for font scaling
+      font-weight: normal;
       margin-left: var(--terra-clinical-result-name-header-cell-unit-margin-left, 0.35714em); // Must use ems for font scaling
       overflow: hidden;
     }

--- a/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
+++ b/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
@@ -57,13 +57,13 @@ const ResultTimeHeaderCell = (props) => {
   );
 
   return (
-    <div
+    <th
       {...customProps}
       className={timeHeaderCellClassnames}
     >
       <div className={dateClassnames}>{date}</div>
       <div className={cx('time')}>{time}</div>
-    </div>
+    </th>
   );
 };
 

--- a/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/flowsheet-result-cell/SemanticTableWithFlowsheetResultCell.test.jsx
+++ b/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/flowsheet-result-cell/SemanticTableWithFlowsheetResultCell.test.jsx
@@ -1,0 +1,266 @@
+import React from 'react';
+import { FlowsheetResultCell, ResultNameHeaderCell } from 'terra-clinical-result/lib/index';
+import Table, {
+  Header,
+  Row,
+  Body,
+  Cell,
+} from 'terra-html-table';
+
+const defaultBloodPressureResult = [
+  {
+    id: '1',
+    systolic: {
+      eventId: '2',
+      result: {
+        value: '130',
+        unit: 'mmHg',
+      },
+      interpretation: 'high',
+    },
+    diastolic: {
+      eventId: '3',
+      result: {
+        value: '80',
+        unit: 'mmHg',
+      },
+    },
+  },
+];
+
+const multipleResults = [
+  {
+    id: '4',
+    systolic: {
+      eventId: '5',
+      result: {
+        value: '140',
+        unit: 'mmHg',
+      },
+      interpretation: 'high',
+    },
+    diastolic: {
+      eventId: '6',
+      result: {
+        value: '77',
+        unit: 'mmHg',
+      },
+      interpretation: 'critical',
+    },
+  },
+  {
+    id: '7',
+    systolic: {
+      eventId: '8',
+      result: {
+        value: '140',
+        unit: 'mmHg',
+      },
+      interpretation: 'high',
+    },
+    diastolic: {
+      eventId: '9',
+      result: {
+        value: '77',
+        unit: 'mmHg',
+      },
+      interpretation: 'critical',
+    },
+  },
+];
+
+const multipleDecoratedResults = [
+  {
+    id: '10',
+    systolic: {
+      eventId: '11',
+      result: {
+        value: '140',
+        unit: 'mmHg',
+      },
+      interpretation: 'high',
+    },
+    diastolic: {
+      eventId: '12',
+      result: {
+        value: '77',
+        unit: 'mmHg',
+      },
+      interpretation: 'critical',
+      isUnverified: false,
+      isModified: true,
+      hasComment: true,
+    },
+  },
+  {
+    id: '13',
+    systolic: {
+      eventId: '14',
+      result: {
+        value: '140',
+        unit: 'mmHg',
+      },
+      interpretation: 'high',
+    },
+    diastolic: {
+      eventId: '15',
+      result: {
+        value: '77',
+        unit: 'mmHg',
+      },
+      interpretation: 'critical',
+      isUnverified: true,
+    },
+  },
+];
+
+const decoratedResult = [
+  {
+    id: '16',
+    systolic: {
+      eventId: '17',
+      result: {
+        value: '85',
+        unit: 'mmHg',
+      },
+      interpretation: 'low',
+    },
+    diastolic: {
+      eventId: '18',
+      result: {
+        value: '77',
+        unit: 'mmHg',
+      },
+      isUnverified: false,
+      isModified: true,
+      hasComment: true,
+    },
+  },
+];
+
+const partialResultWithNoDataPropSystolic = [
+  {
+    id: '19',
+    systolic: {
+      eventId: '20',
+      resultNoData: true,
+    },
+    diastolic: {
+      eventId: '21',
+      result: {
+        value: '85',
+        unit: 'mmHg',
+      },
+    },
+  },
+];
+
+const partialResultWithNoDataPropDiastolic = [
+  {
+    id: '22',
+    systolic: {
+      eventId: '23',
+      result: {
+        value: '170',
+        unit: 'mmHg',
+      },
+      interpretation: 'critical',
+    },
+    diastolic: {
+      eventId: '24',
+      resultNoData: true,
+    },
+  },
+];
+
+const unverifiedResult = [
+  {
+    id: '25',
+    systolic: {
+      eventId: '26',
+      result: {
+        value: '140',
+        unit: 'mmHg',
+      },
+      interpretation: 'high',
+      isUnverified: true,
+    },
+    diastolic: {
+      eventId: '27',
+      result: {
+        value: '77',
+        unit: 'mmHg',
+      },
+      interpretation: 'critical',
+      isUnverified: true,
+    },
+  },
+];
+
+const SemanticTableWithFlowsheetResultCell = () => (
+  <Table>
+    <Header>
+      <ResultNameHeaderCell key="notes" resultName="Notes" />
+      <ResultNameHeaderCell key="bp" resultName="Blood Pressure" />
+      <ResultNameHeaderCell key="date" resultName="Date" />
+    </Header>
+    <Body>
+      <Row>
+        {/* This example cell shows a standard result */}
+        <Cell key="notes">Standard Result (With Unit)</Cell>
+        <FlowsheetResultCell key="bp" resultDataSet={defaultBloodPressureResult} />
+        <Cell key="date">May 12th</Cell>
+      </Row>
+      <Row>
+        {/* This example cell shows mulitple resutls */}
+        <Cell key="notes">Multiple Results</Cell>
+        <FlowsheetResultCell key="bp" resultDataSet={multipleResults} hideUnit />
+        <Cell key="date">May 12th</Cell>
+      </Row>
+      <Row>
+        {/* This example cell shows an multiple decorated results */}
+        <Cell key="notes">Multiple Decorated Results</Cell>
+        <FlowsheetResultCell key="bp" resultDataSet={multipleDecoratedResults} hideUnit />
+        <Cell key="date">May 12th</Cell>
+      </Row>
+      <Row>
+        {/* This example cell shows a decorated result */}
+        <Cell key="notes">Decorated Result</Cell>
+        <FlowsheetResultCell key="bp" resultDataSet={decoratedResult} hideUnit />
+        <Cell key="date">May 12th</Cell>
+      </Row>
+      <Row>
+        {/* This example cell shows a partial Blood Pressure no data display using the `resultNoData` property name for the Diastolic result */}
+        <Cell key="notes">Partial Result, Diastolic</Cell>
+        <FlowsheetResultCell key="bp" resultDataSet={partialResultWithNoDataPropDiastolic} hideUnit />
+        <Cell key="date">May 12th</Cell>
+      </Row>
+      <Row>
+        {/* This example cell shows a partial Blood Pressure no data display using the `resultNoData` property name for the Systolic result */}
+        <Cell key="notes">Partial Result, Systolic</Cell>
+        <FlowsheetResultCell key="bp" resultDataSet={partialResultWithNoDataPropSystolic} hideUnit />
+        <Cell key="date">May 12th</Cell>
+      </Row>
+      <Row>
+        {/* This example cell shows an unverified result */}
+        <Cell key="notes">Unverified Result</Cell>
+        <FlowsheetResultCell key="bp" resultDataSet={unverifiedResult} hideUnit />
+        <Cell key="date">May 12th</Cell>
+      </Row>
+      <Row>
+        {/* This example cell shows a standard result with the `hasResultNoData` prop */}
+        <Cell key="notes">No Data Result</Cell>
+        <FlowsheetResultCell key="bp" hasResultNoData />
+        <Cell key="date">May 12th</Cell>
+      </Row>
+      <Row>
+        {/* This example cell shows a result with an error */}
+        <Cell key="notes">Error Result</Cell>
+        <FlowsheetResultCell key="bp" hasResultError />
+        <Cell key="date">May 12th</Cell>
+      </Row>
+    </Body>
+  </Table>
+);
+
+export default SemanticTableWithFlowsheetResultCell;

--- a/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/result-name-header-cell/SemanticTableWithResultNameHeaderCell.test.jsx
+++ b/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/result-name-header-cell/SemanticTableWithResultNameHeaderCell.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ResultNameHeaderCell, FlowsheetResultCell } from 'terra-clinical-result/lib/index';
+import Table, {
+  Header,
+  Row,
+  Body,
+  Cell,
+} from 'terra-html-table';
+
+const defaultBloodPressureResult = [
+  {
+    id: '1',
+    systolic: {
+      eventId: '2',
+      result: {
+        value: '130',
+        unit: 'mmHg',
+      },
+      interpretation: 'high',
+    },
+    diastolic: {
+      eventId: '3',
+      result: {
+        value: '80',
+        unit: 'mmHg',
+      },
+    },
+  },
+];
+
+const SemanticTableWithResultNameHeaderCell = () => (
+  <Table>
+    <Header>
+      <ResultNameHeaderCell key="temp" resultName="Temp" unit="degC" />
+      <ResultNameHeaderCell key="bp" resultName="BP" unit="mmHg" />
+      <ResultNameHeaderCell key="hr" resultName="HR" unit="mmHg" />
+    </Header>
+    <Body>
+      <Row>
+        <Cell key="temp">98.6</Cell>
+        <FlowsheetResultCell key="bp" resultDataSet={defaultBloodPressureResult} />
+        <Cell key="hr">100</Cell>
+      </Row>
+    </Body>
+  </Table>
+);
+
+export default SemanticTableWithResultNameHeaderCell;

--- a/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/result-time-header-cell/SemanticTableWithResultTimeHeaderCell.test.jsx
+++ b/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/result-time-header-cell/SemanticTableWithResultTimeHeaderCell.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ResultTimeHeaderCell } from 'terra-clinical-result/lib/index';
+import Table, {
+  Header,
+  Row,
+  Body,
+} from 'terra-html-table';
+import FlowsheetResultCell from '../../../../flowsheet-result-cell/FlowsheetResultCell';
+
+const defaultBloodPressureResult = [
+  {
+    id: '1',
+    systolic: {
+      eventId: '2',
+      result: {
+        value: '130',
+        unit: 'mmHg',
+      },
+      interpretation: 'high',
+    },
+    diastolic: {
+      eventId: '3',
+      result: {
+        value: '80',
+        unit: 'mmHg',
+      },
+    },
+  },
+];
+
+const SemanticTableWithResultTimeHeaderCell = () => (
+  <Table>
+    <Header>
+      <ResultTimeHeaderCell key="time1" date="Dec 21, 2010" time="20:59" />
+      <ResultTimeHeaderCell key="time2" date="Dec 22, 2010" time="22:00" />
+      <ResultTimeHeaderCell key="time3" date="Dec 23, 2010" time="23:59" />
+    </Header>
+    <Body>
+      <Row>
+        <FlowsheetResultCell key="time1" resultDataSet={defaultBloodPressureResult} />
+        <FlowsheetResultCell key="time2" resultDataSet={defaultBloodPressureResult} />
+        <FlowsheetResultCell key="time3" resultDataSet={defaultBloodPressureResult} />
+      </Row>
+    </Body>
+  </Table>
+);
+
+export default SemanticTableWithResultTimeHeaderCell;

--- a/packages/terra-clinical-result/tests/jest/flowsheet-result-cell/__snapshots__/FlowsheetResultCell.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/flowsheet-result-cell/__snapshots__/FlowsheetResultCell.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FlowsheetResultCell correctly applies the theme context className 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact orion-fusion-theme"
 >
   <div
@@ -22,33 +22,38 @@ exports[`FlowsheetResultCell correctly applies the theme context className 1`] =
     />
   </div>
   <div
-    className="additional-end-display no-accessory-icons"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResults"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display no-accessory-icons"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
+      />
     </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell paddingStyle should render when given compact 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -69,33 +74,38 @@ exports[`FlowsheetResultCell paddingStyle should render when given compact 1`] =
     />
   </div>
   <div
-    className="additional-end-display no-accessory-icons"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResults"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display no-accessory-icons"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
+      />
     </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell paddingStyle should render when given none 1`] = `
-<div
+<td
   className="flowsheet-result-cell"
 >
   <div
@@ -116,33 +126,38 @@ exports[`FlowsheetResultCell paddingStyle should render when given none 1`] = `
     />
   </div>
   <div
-    className="additional-end-display no-accessory-icons"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResults"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display no-accessory-icons"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
+      />
     </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell paddingStyle should render when given standard 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-standard"
 >
   <div
@@ -163,33 +178,38 @@ exports[`FlowsheetResultCell paddingStyle should render when given standard 1`] 
     />
   </div>
   <div
-    className="additional-end-display no-accessory-icons"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResults"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display no-accessory-icons"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
+      />
     </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should pass hideUnit down 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -211,33 +231,38 @@ exports[`FlowsheetResultCell should pass hideUnit down 1`] = `
     />
   </div>
   <div
-    className="additional-end-display no-accessory-icons"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResults"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display no-accessory-icons"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
+      />
     </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render a NoData if hasResultNoData is true 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -246,11 +271,11 @@ exports[`FlowsheetResultCell should render a NoData if hasResultNoData is true 1
   >
     <InjectIntl(KnownNoData) />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render a ResultError if hasResultError is true 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -259,11 +284,11 @@ exports[`FlowsheetResultCell should render a ResultError if hasResultError is tr
   >
     <InjectIntl(ResultError) />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render a entered-in-error status standard result 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -273,33 +298,38 @@ exports[`FlowsheetResultCell should render a entered-in-error status standard re
     <InjectIntl(EnteredInError) />
   </div>
   <div
-    className="additional-end-display no-accessory-icons"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResults"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display no-accessory-icons"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
+      />
     </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render an error when given no result data 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -308,11 +338,11 @@ exports[`FlowsheetResultCell should render an error when given no result data 1`
   >
     <InjectIntl(ResultError) />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render an error with bad data 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -321,11 +351,11 @@ exports[`FlowsheetResultCell should render an error with bad data 1`] = `
   >
     <InjectIntl(ResultError) />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render blood pressure correctly with an interpretation and unverified result 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -361,50 +391,55 @@ exports[`FlowsheetResultCell should render blood pressure correctly with an inte
     />
   </div>
   <div
-    className="additional-end-display"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResultsAndIcons"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
-    </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
-  </div>
-  <div
-    className="end-accessory-icons"
-    key="EndAccessoryIcons-111"
-  >
-    <div
-      className="end-accessory-stack"
-    >
-      <IconDiamond
-        a11yLabel="Terra.clinicalResult.resultUnverified"
-        className="icon-unverified"
-        focusable="true"
-        role="img"
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
       />
     </div>
+    <div
+      className="end-accessory-icons"
+      key="EndAccessoryIcons-111"
+    >
+      <div
+        className="end-accessory-stack"
+      >
+        <IconDiamond
+          a11yLabel="Terra.clinicalResult.resultUnverified"
+          className="icon-unverified"
+          focusable="true"
+          role="img"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </div>
+    </div>
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render both entered-in-error status bloodpressure result 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -414,33 +449,38 @@ exports[`FlowsheetResultCell should render both entered-in-error status bloodpre
     <InjectIntl(EnteredInError) />
   </div>
   <div
-    className="additional-end-display no-accessory-icons"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResults"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display no-accessory-icons"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
+      />
     </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render correctly when a multiple results cell contains icons 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -464,52 +504,57 @@ exports[`FlowsheetResultCell should render correctly when a multiple results cel
     />
   </div>
   <div
-    className="additional-end-display"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResultsAndIcons"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
-    </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
-  </div>
-  <div
-    className="end-accessory-icons"
-    key="EndAccessoryIcons-111"
-  >
-    <div
-      className="end-accessory-stack"
-    >
-      <IconComment
-        a11yLabel="Terra.clinicalResult.resultComment"
-        className="icon-comment"
-        data-name="Layer 1"
-        focusable="true"
-        isBidi={true}
-        role="img"
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
       />
     </div>
+    <div
+      className="end-accessory-icons"
+      key="EndAccessoryIcons-111"
+    >
+      <div
+        className="end-accessory-stack"
+      >
+        <IconComment
+          a11yLabel="Terra.clinicalResult.resultComment"
+          className="icon-comment"
+          data-name="Layer 1"
+          focusable="true"
+          isBidi={true}
+          role="img"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </div>
+    </div>
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render correctly with all normal results 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -532,33 +577,38 @@ exports[`FlowsheetResultCell should render correctly with all normal results 1`]
     />
   </div>
   <div
-    className="additional-end-display no-accessory-icons"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResults"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display no-accessory-icons"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
+      />
     </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render correctly with an interpretation and unverified result 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -582,50 +632,55 @@ exports[`FlowsheetResultCell should render correctly with an interpretation and 
     />
   </div>
   <div
-    className="additional-end-display"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResultsAndIcons"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
-    </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
-  </div>
-  <div
-    className="end-accessory-icons"
-    key="EndAccessoryIcons-111"
-  >
-    <div
-      className="end-accessory-stack"
-    >
-      <IconDiamond
-        a11yLabel="Terra.clinicalResult.resultUnverified"
-        className="icon-unverified"
-        focusable="true"
-        role="img"
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
       />
     </div>
+    <div
+      className="end-accessory-icons"
+      key="EndAccessoryIcons-111"
+    >
+      <div
+        className="end-accessory-stack"
+      >
+        <IconDiamond
+          a11yLabel="Terra.clinicalResult.resultUnverified"
+          className="icon-unverified"
+          focusable="true"
+          role="img"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </div>
+    </div>
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render correctly with at least 1 critical or out of range result 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -648,33 +703,38 @@ exports[`FlowsheetResultCell should render correctly with at least 1 critical or
     />
   </div>
   <div
-    className="additional-end-display no-accessory-icons interpretation-critical"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResults"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display no-accessory-icons interpretation-critical"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleResults"
+      />
     </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleResults"
-    />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render systolic entered-in-error status bloodpressure result 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -684,33 +744,38 @@ exports[`FlowsheetResultCell should render systolic entered-in-error status bloo
     <InjectIntl(EnteredInError) />
   </div>
   <div
-    className="additional-end-display no-accessory-icons"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResults"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display no-accessory-icons"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
+      />
     </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render when given blood pressure diastolic result data with no id 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -732,11 +797,11 @@ exports[`FlowsheetResultCell should render when given blood pressure diastolic r
       key="ClinicalResultBloodPressure-111.2"
     />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render when given blood pressure systolic result data with no id 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -758,11 +823,11 @@ exports[`FlowsheetResultCell should render when given blood pressure systolic re
       }
     />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render when given result data 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -783,33 +848,38 @@ exports[`FlowsheetResultCell should render when given result data 1`] = `
     />
   </div>
   <div
-    className="additional-end-display no-accessory-icons"
-    key="AdditionalResultsDisplay-111"
+    className="end-display"
+    key="EndDisplay-AdditionalResults"
   >
     <div
-      aria-hidden="true"
-      className="additional-results-stack"
+      className="additional-end-display no-accessory-icons"
+      key="AdditionalResultsDisplay-111"
     >
-      <span
-        className="additional-results-value"
+      <div
+        aria-hidden="true"
+        className="additional-results-stack"
       >
-        2
-      </span>
-      <span
-        className="additional-results-value"
-      >
-        2
-      </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+        <span
+          className="additional-results-value"
+        >
+          2
+        </span>
+      </div>
+      <VisuallyHiddenText
+        text="Terra.clinicalResult.multipleNormalResults"
+      />
     </div>
-    <VisuallyHiddenText
-      text="Terra.clinicalResult.multipleNormalResults"
-    />
   </div>
-</div>
+</td>
 `;
 
 exports[`FlowsheetResultCell should render when given result data with no event id 1`] = `
-<div
+<td
   className="flowsheet-result-cell padding-compact"
 >
   <div
@@ -829,5 +899,5 @@ exports[`FlowsheetResultCell should render when given result data with no event 
       }
     />
   </div>
-</div>
+</td>
 `;

--- a/packages/terra-clinical-result/tests/jest/result-name-header-cell/__snapshots__/ResultNameHeaderCell.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/result-name-header-cell/__snapshots__/ResultNameHeaderCell.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ResultNameHeaderCell correctly applies the theme context className 1`] = `
-<div
+<th
   className="clinical-result-name-header-cell padding-compact orion-fusion-theme"
 >
   <div
@@ -14,11 +14,11 @@ exports[`ResultNameHeaderCell correctly applies the theme context className 1`] 
   >
     Unit
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultNameHeaderCell paddingStyle - should render with compact 1`] = `
-<div
+<th
   className="clinical-result-name-header-cell padding-compact"
 >
   <div
@@ -26,11 +26,11 @@ exports[`ResultNameHeaderCell paddingStyle - should render with compact 1`] = `
   >
     Name
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultNameHeaderCell paddingStyle - should render with none 1`] = `
-<div
+<th
   className="clinical-result-name-header-cell"
 >
   <div
@@ -38,11 +38,11 @@ exports[`ResultNameHeaderCell paddingStyle - should render with none 1`] = `
   >
     Name
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultNameHeaderCell paddingStyle - should render with standard 1`] = `
-<div
+<th
   className="clinical-result-name-header-cell padding-standard"
 >
   <div
@@ -50,11 +50,11 @@ exports[`ResultNameHeaderCell paddingStyle - should render with standard 1`] = `
   >
     Name
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultNameHeaderCell should render a result name 1`] = `
-<div
+<th
   className="clinical-result-name-header-cell padding-compact"
 >
   <div
@@ -62,11 +62,11 @@ exports[`ResultNameHeaderCell should render a result name 1`] = `
   >
     Name
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultNameHeaderCell should render a unit 1`] = `
-<div
+<th
   className="clinical-result-name-header-cell padding-compact"
 >
   <div
@@ -79,11 +79,11 @@ exports[`ResultNameHeaderCell should render a unit 1`] = `
   >
     Unit
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultNameHeaderCell should render correctly when a full result name is provided 1`] = `
-<div
+<th
   className="clinical-result-name-header-cell padding-compact"
 >
   <div
@@ -95,11 +95,11 @@ exports[`ResultNameHeaderCell should render correctly when a full result name is
   <VisuallyHiddenText
     text="Full result name"
   />
-</div>
+</th>
 `;
 
 exports[`ResultNameHeaderCell should render correctly when a full unit name is provided 1`] = `
-<div
+<th
   className="clinical-result-name-header-cell padding-compact"
 >
   <div
@@ -116,11 +116,11 @@ exports[`ResultNameHeaderCell should render correctly when a full unit name is p
   <VisuallyHiddenText
     text="Full unit name"
   />
-</div>
+</th>
 `;
 
 exports[`ResultNameHeaderCell typeIndicator - should render with calculated 1`] = `
-<div
+<th
   className="clinical-result-name-header-cell padding-compact"
 >
   <div
@@ -134,11 +134,11 @@ exports[`ResultNameHeaderCell typeIndicator - should render with calculated 1`] 
     />
     Name
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultNameHeaderCell typeIndicator - should render with none 1`] = `
-<div
+<th
   className="clinical-result-name-header-cell padding-compact"
 >
   <div
@@ -146,5 +146,5 @@ exports[`ResultNameHeaderCell typeIndicator - should render with none 1`] = `
   >
     Name
   </div>
-</div>
+</th>
 `;

--- a/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ResultTimeHeaderCell correctly applies the theme context className 1`] = `
-<div
+<th
   className="clinical-result-time-header-cell padding-compact orion-fusion-theme"
 >
   <div
@@ -14,11 +14,11 @@ exports[`ResultTimeHeaderCell correctly applies the theme context className 1`] 
   >
     10:00 PM
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultTimeHeaderCell paddingStyle - should render with compact 1`] = `
-<div
+<th
   className="clinical-result-time-header-cell padding-compact"
 >
   <div
@@ -31,11 +31,11 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with compact 1`] = `
   >
     10:00 PM
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultTimeHeaderCell paddingStyle - should render with none 1`] = `
-<div
+<th
   className="clinical-result-time-header-cell"
 >
   <div
@@ -48,11 +48,11 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with none 1`] = `
   >
     10:00 PM
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultTimeHeaderCell paddingStyle - should render with standard 1`] = `
-<div
+<th
   className="clinical-result-time-header-cell padding-standard"
 >
   <div
@@ -65,11 +65,11 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with standard 1`] = `
   >
     10:00 PM
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultTimeHeaderCell should hide date 1`] = `
-<div
+<th
   className="clinical-result-time-header-cell padding-compact"
 >
   <div
@@ -82,11 +82,11 @@ exports[`ResultTimeHeaderCell should hide date 1`] = `
   >
     10:00 PM
   </div>
-</div>
+</th>
 `;
 
 exports[`ResultTimeHeaderCell should render a date and time 1`] = `
-<div
+<th
   className="clinical-result-time-header-cell padding-compact"
 >
   <div
@@ -99,5 +99,5 @@ exports[`ResultTimeHeaderCell should render a date and time 1`] = `
   >
     10:00 PM
   </div>
-</div>
+</th>
 `;


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
FlowsheetResultCell, ResultNameHeaderCell, and ResultTimeHeaderCell are presumed to be used as part of a table in which they do not provide the proper context of a Cell or Header Cell for a table. 

**What was changed:**
We need to change the HTML tags from div to the proper corresponding tags for Header Cells and Cells. That would be _td_ for FlowsheetResultCell and _th_ for ResultNameHeaderCell and ResultTimeHeaderCell.

Also needed to add site tests for each in order to properly validate this change, this is because the 'tables' created on the site currently are not actual semantic html tables. That means the screenreader doesn't pick up on the new context of cell or header cell, just reads them as it has been previously. This is good in that changing the tags doesn't cause any visual changes to current implementation if you aren't using a table.

That being said, when using the semantic html table for certain flowsheet result cell entries I'm having issues with the css formatting - specifically when dealing with the spacing of certain icons or with the multiple result custom icon being too wide. Overall the cell itself is also much wider than seemingly needed - I think this and the icon issue are caused because of the actual content styling inside the ResultFlowsheetCell so I'm not sure yet what I might need to do. Looking into that now. 
Example of the styling issues:
<img width="1400" alt="Example-of-bad-css" src="https://github.com/cerner/terra-clinical/assets/40574651/957618cc-727d-482f-9600-8b7459ca157f">

Either way we still need to test it in a real table so I opted to use terra's existing [html table component](https://engineering.cerner.com/terra-ui/components/cerner-terra-core-docs/html-table/about) in order to build that out.

**Why it was changed:**
We need proper context for these components when they are used within a semantic table.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9063<!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra

Flowsheet cell test:

https://github.com/cerner/terra-clinical/assets/40574651/7bc953c8-64eb-40c1-9c77-b8bc74f9a8cf

https://github.com/cerner/terra-clinical/assets/40574651/adbcd741-115f-433e-936b-daa6243f4cd5

Header cell tests:


https://github.com/cerner/terra-clinical/assets/40574651/e762b670-0e39-4311-b53e-3a7af8bcf6d3

https://github.com/cerner/terra-clinical/assets/40574651/df0640f4-10bb-4623-b449-688dd398aa6a
