### PR TITLE
[terra-clinical-result] Restructure the Blood Pressure with additional displays as a group

### DIFF
--- a/packages/terra-clinical-result/CHANGELOG.md
+++ b/packages/terra-clinical-result/CHANGELOG.md
@@ -13,6 +13,7 @@
   * Added screen-reader support for clinical-result FlowsheetResultCell EnteredInError.
   * Added screen-reader support for clinical-result FlowsheetResultCell with multiple results.
   * Added screen-reader support for clinical-result ResultNameHeaderCell. Two new optional props are added for providing a full name of the result name and unit respectively.
+  * Added screen-reader support for Blood Pressure with additional displays as a group. An additional prop is added for making the blood pressure results a group.
 
 ## 1.16.0 - (March 29, 2023)
 

--- a/packages/terra-clinical-result/package.json
+++ b/packages/terra-clinical-result/package.json
@@ -36,7 +36,8 @@
     "terra-icon": "^3.53.0",
     "terra-mixins": "^1.0.0",
     "terra-theme-context": "^1.0.0",
-    "terra-visually-hidden-text": "^2.36.0"
+    "terra-visually-hidden-text": "^2.36.0",
+    "uuid": "8.2.0"
   },
   "scripts": {
     "compile": "babel --root-mode upward src --out-dir lib --copy-files",

--- a/packages/terra-clinical-result/src/terra-dev-site/doc/example/clinical-result-blood-pressure/ClinicalResultBloodPressureExtraDisplays.jsx
+++ b/packages/terra-clinical-result/src/terra-dev-site/doc/example/clinical-result-blood-pressure/ClinicalResultBloodPressureExtraDisplays.jsx
@@ -9,7 +9,7 @@ const bloodpressureResultValue = {
       value: '120',
       unit: 'mmHg',
     },
-    conceptDisplay: 'Blood Pressure Systolic',
+    conceptDisplay: 'Systolic',
     datetimeDisplay: 'Nov 23, 2019 13:31:31',
   },
   diastolic: {
@@ -18,9 +18,10 @@ const bloodpressureResultValue = {
       value: '80',
       unit: 'mmHg',
     },
-    conceptDisplay: 'Blood Pressure Diastolic',
-    datetimeDisplay: 'Nov 23, 2019 13:31:44',
+    conceptDisplay: 'Diastolic',
+    datetimeDisplay: 'Nov 23, 2019 13:31:31',
   },
+  isBloodPressureGrouped: true,
 };
 
 export default () => <ClinicalResultBloodPressure {...bloodpressureResultValue} />;

--- a/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/TestResults.jsx
+++ b/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/TestResults.jsx
@@ -162,6 +162,7 @@ const ExtraDisplaysBloodPressureResult = {
     conceptDisplay: 'Blood Pressure Diastolic',
     datetimeDisplay: 'Nov 23, 2019 13:31:44',
   },
+  isBloodPressureGrouped: true,
 };
 
 const MixedBPResultValue = {

--- a/packages/terra-clinical-result/tests/jest/ClinicalResultBloodPressure.test.jsx
+++ b/packages/terra-clinical-result/tests/jest/ClinicalResultBloodPressure.test.jsx
@@ -6,8 +6,11 @@ import {
   DefaultBloodPressureResult,
   DefaultSystolicResult,
   DefaultDiastolicResult,
+  ExtraDisplaysBloodPressureResult,
   NoDataResult,
 } from '../../src/terra-dev-site/test/clinical-result/TestResults';
+
+jest.mock('uuid', () => ({ v4: () => '00000000-0000-0000-0000-000000000000' }));
 
 describe('ClinicalResultBloodPressure', () => {
   it('should render a ResultError if hasResultError is true', () => {
@@ -18,6 +21,22 @@ describe('ClinicalResultBloodPressure', () => {
   it('should render a NoData if hasResultNoData is true', () => {
     const result = shallowWithIntl(<ClinicalResultBloodPressure hasResultNoData />).dive();
     expect(result).toMatchSnapshot();
+  });
+
+  it('should render ClinicalResultBloodPressure if isBloodPressureGrouped is true', () => {
+    const result = shallowWithIntl(<ClinicalResultBloodPressure {...DefaultBloodPressureResult} isBloodPressureGrouped />).dive();
+    expect(result.find('VisuallyHiddenText').at(0).prop('text')).toEqual('Terra.clinicalResult.bloodPressure');
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should set the hidden text ID', () => {
+    const result = shallowWithIntl(<ClinicalResultBloodPressure {...DefaultBloodPressureResult} isBloodPressureGrouped />).dive();
+    expect(result.find('VisuallyHiddenText').prop('id')).toEqual('00000000-0000-0000-0000-000000000000-hiddenText');
+  });
+
+  it('should set the dateTime display ID', () => {
+    const result = shallowWithIntl(<ClinicalResultBloodPressure {...ExtraDisplaysBloodPressureResult} />).dive();
+    expect(result.find('.datetime-display').prop('id')).toEqual('00000000-0000-0000-0000-000000000000-datetimeDisplay');
   });
 
   it('should render a default ClinicalResultBloodPressure', () => {

--- a/packages/terra-clinical-result/tests/jest/__snapshots__/ClinicalResultBloodPressure.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/__snapshots__/ClinicalResultBloodPressure.test.jsx.snap
@@ -4,44 +4,46 @@ exports[`ClinicalResultBloodPressure - Diastolic - should pass certain props to 
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={true}
-        id="111"
-        result={Object {}}
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.2"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={true}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "interpretation": "critical",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={true}
+          id="111"
+          result={Object {}}
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.2"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={true}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "interpretation": "critical",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -49,54 +51,56 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a commented res
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.2"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "hasComment": true,
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.2"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "hasComment": true,
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
-      <IconComment
-        a11yLabel="Terra.clinicalResult.resultComment"
-        className="icon-comment"
-        data-name="Layer 1"
-        focusable="true"
-        isBidi={true}
-        role="img"
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+          type="Diastolic"
+        />
+        <IconComment
+          a11yLabel="Terra.clinicalResult.resultComment"
+          className="icon-comment"
+          data-name="Layer 1"
+          focusable="true"
+          isBidi={true}
+          role="img"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -104,46 +108,48 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a entered-in-er
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display status-in-error"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display status-in-error"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.2"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "interpretation": "critical",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
-            "status": "entered-in-error",
-            "statusInError": true,
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.2"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "interpretation": "critical",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+              "status": "entered-in-error",
+              "statusInError": true,
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -151,52 +157,54 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a modified resu
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.2"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "isModified": true,
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.2"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "isModified": true,
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
-      <IconModified
-        a11yLabel="Terra.clinicalResult.resultModified"
-        className="icon-modified"
-        focusable="true"
-        role="img"
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+          type="Diastolic"
+        />
+        <IconModified
+          a11yLabel="Terra.clinicalResult.resultModified"
+          className="icon-modified"
+          focusable="true"
+          role="img"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -204,50 +212,52 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a result with a
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.2"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedConceptDisplay": "temperature oral",
-            "cleanedUnit": "mmhg",
-            "conceptDisplay": "Temperature Oral",
-            "eventId": "111.2",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.2"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedConceptDisplay": "temperature oral",
+              "cleanedUnit": "mmhg",
+              "conceptDisplay": "Temperature Oral",
+              "eventId": "111.2",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
-  <div
-    className="concept-display"
-  >
-    Temperature Oral
-  </div>
+    <div
+      className="concept-display"
+    >
+      Temperature Oral
+    </div>
+  </span>
 </div>
 `;
 
@@ -255,50 +265,53 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a result with a
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.2"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedDatetimeDisplay": "nov 23, 2019 13:31:31",
-            "cleanedUnit": "mmhg",
-            "datetimeDisplay": "Nov 23, 2019 13:31:31",
-            "eventId": "111.2",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.2"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedDatetimeDisplay": "nov 23, 2019 13:31:31",
+              "cleanedUnit": "mmhg",
+              "datetimeDisplay": "Nov 23, 2019 13:31:31",
+              "eventId": "111.2",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
-  <div
-    className="datetime-display"
-  >
-    Nov 23, 2019 13:31:31
-  </div>
+    <div
+      className="datetime-display"
+      id="00000000-0000-0000-0000-000000000000-datetimeDisplay"
+    >
+      Nov 23, 2019 13:31:31
+    </div>
+  </span>
 </div>
 `;
 
@@ -306,43 +319,45 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a result with u
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={true}
-        id="111"
-        result={Object {}}
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.2"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={true}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={true}
+          id="111"
+          result={Object {}}
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.2"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={true}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -350,52 +365,54 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render an unverified r
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.2"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "isUnverified": true,
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.2"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "isUnverified": true,
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
-      <IconDiamond
-        a11yLabel="Terra.clinicalResult.resultUnverified"
-        className="icon-unverified"
-        focusable="true"
-        role="img"
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+          type="Diastolic"
+        />
+        <IconDiamond
+          a11yLabel="Terra.clinicalResult.resultUnverified"
+          className="icon-unverified"
+          focusable="true"
+          role="img"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -403,54 +420,56 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render diastolic with 
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        result={
-          Object {
-            "eventId": "",
-            "hasComment": false,
-            "interpretation": "normal",
-            "isModified": false,
-            "isUnverified": false,
-            "noData": true,
-            "result": Object {
-              "unit": "",
-              "value": null,
-            },
-            "resultNoData": true,
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          result={
+            Object {
+              "eventId": "",
+              "hasComment": false,
+              "interpretation": "normal",
+              "isModified": false,
+              "isUnverified": false,
+              "noData": true,
+              "result": Object {
+                "unit": "",
+                "value": null,
+              },
+              "resultNoData": true,
+            }
+          }
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -458,40 +477,42 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render with error 1`] 
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        result={Object {}}
-        type="Diastolic"
-      />
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
+          }
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          result={Object {}}
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -499,43 +520,45 @@ exports[`ClinicalResultBloodPressure - Systolic - should pass certain props to O
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={true}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "interpretation": "critical",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={true}
-        id="111"
-        result={Object {}}
-        type="Diastolic"
-      />
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={true}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "interpretation": "critical",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
+          }
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={true}
+          id="111"
+          result={Object {}}
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -543,53 +566,55 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a commented resu
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "hasComment": true,
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Diastolic"
-      />
-      <IconComment
-        a11yLabel="Terra.clinicalResult.resultComment"
-        className="icon-comment"
-        data-name="Layer 1"
-        focusable="true"
-        isBidi={true}
-        role="img"
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "hasComment": true,
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
+          }
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Diastolic"
+        />
+        <IconComment
+          a11yLabel="Terra.clinicalResult.resultComment"
+          className="icon-comment"
+          data-name="Layer 1"
+          focusable="true"
+          isBidi={true}
+          role="img"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -597,45 +622,47 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a entered-in-err
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display status-in-error"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display status-in-error"
     >
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "interpretation": "critical",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-            "status": "entered-in-error",
-            "statusInError": true,
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Diastolic"
-      />
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "interpretation": "critical",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+              "status": "entered-in-error",
+              "statusInError": true,
+            }
+          }
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -643,51 +670,53 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a modified resul
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "isModified": true,
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Diastolic"
-      />
-      <IconModified
-        a11yLabel="Terra.clinicalResult.resultModified"
-        className="icon-modified"
-        focusable="true"
-        role="img"
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "isModified": true,
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
+          }
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Diastolic"
+        />
+        <IconModified
+          a11yLabel="Terra.clinicalResult.resultModified"
+          className="icon-modified"
+          focusable="true"
+          role="img"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -695,49 +724,51 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a result with a 
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedConceptDisplay": "temperature oral",
-            "cleanedUnit": "mmhg",
-            "conceptDisplay": "Temperature Oral",
-            "eventId": "111.1",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Diastolic"
-      />
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedConceptDisplay": "temperature oral",
+              "cleanedUnit": "mmhg",
+              "conceptDisplay": "Temperature Oral",
+              "eventId": "111.1",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
+          }
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
-  <div
-    className="concept-display"
-  >
-    Temperature Oral
-  </div>
+    <div
+      className="concept-display"
+    >
+      Temperature Oral
+    </div>
+  </span>
 </div>
 `;
 
@@ -745,49 +776,52 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a result with a 
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedDatetimeDisplay": "nov 23, 2019 13:31:31",
-            "cleanedUnit": "mmhg",
-            "datetimeDisplay": "Nov 23, 2019 13:31:31",
-            "eventId": "111.1",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Diastolic"
-      />
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedDatetimeDisplay": "nov 23, 2019 13:31:31",
+              "cleanedUnit": "mmhg",
+              "datetimeDisplay": "Nov 23, 2019 13:31:31",
+              "eventId": "111.1",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
+          }
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
-  <div
-    className="datetime-display"
-  >
-    Nov 23, 2019 13:31:31
-  </div>
+    <div
+      className="datetime-display"
+      id="00000000-0000-0000-0000-000000000000-datetimeDisplay"
+    >
+      Nov 23, 2019 13:31:31
+    </div>
+  </span>
 </div>
 `;
 
@@ -795,42 +829,44 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a result with un
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={true}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={true}
-        id="111"
-        result={Object {}}
-        type="Diastolic"
-      />
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={true}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
+          }
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={true}
+          id="111"
+          result={Object {}}
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -838,51 +874,53 @@ exports[`ClinicalResultBloodPressure - Systolic - should render an unverified re
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "isUnverified": true,
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={Object {}}
-        type="Diastolic"
-      />
-      <IconDiamond
-        a11yLabel="Terra.clinicalResult.resultUnverified"
-        className="icon-unverified"
-        focusable="true"
-        role="img"
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "isUnverified": true,
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
+          }
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={Object {}}
+          type="Diastolic"
+        />
+        <IconDiamond
+          a11yLabel="Terra.clinicalResult.resultUnverified"
+          className="icon-unverified"
+          focusable="true"
+          role="img"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -890,41 +928,43 @@ exports[`ClinicalResultBloodPressure - Systolic - should render with error 1`] =
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        result={Object {}}
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.2"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          result={Object {}}
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.2"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -932,55 +972,57 @@ exports[`ClinicalResultBloodPressure - Systolic - should render with no data 1`]
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        result={
-          Object {
-            "eventId": "",
-            "hasComment": false,
-            "interpretation": "normal",
-            "isModified": false,
-            "isUnverified": false,
-            "noData": true,
-            "result": Object {
-              "unit": "",
-              "value": null,
-            },
-            "resultNoData": true,
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          result={
+            Object {
+              "eventId": "",
+              "hasComment": false,
+              "interpretation": "normal",
+              "isModified": false,
+              "isUnverified": false,
+              "noData": true,
+              "result": Object {
+                "unit": "",
+                "value": null,
+              },
+              "resultNoData": true,
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
+          }
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -988,53 +1030,119 @@ exports[`ClinicalResultBloodPressure correctly applies the theme context classNa
 <div
   className="clinical-result blood-pressure-result orion-fusion-theme"
 >
-  <div
-    className="decorated-result-display"
+  <span>
+    <div
+      className="decorated-result-display"
+    >
+      <div
+        className="result-display"
+      >
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
+          }
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
+          }
+          type="Diastolic"
+        />
+      </div>
+    </div>
+  </span>
+</div>
+`;
+
+exports[`ClinicalResultBloodPressure should render ClinicalResultBloodPressure if isBloodPressureGrouped is true 1`] = `
+<div
+  className="clinical-result blood-pressure-result"
+>
+  <span
+    aria-labelledby="00000000-0000-0000-0000-000000000000-hiddenText 00000000-0000-0000-0000-000000000000-datetimeDisplay"
+    role="group"
   >
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <VisuallyHiddenText
+          aria-hidden="true"
+          id="00000000-0000-0000-0000-000000000000-hiddenText"
+          text="Terra.clinicalResult.bloodPressure"
+        />
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
+          }
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -1046,53 +1154,55 @@ exports[`ClinicalResultBloodPressure should render a default ClinicalResultBlood
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
+          }
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -1100,53 +1210,55 @@ exports[`ClinicalResultBloodPressure should render a truncated ClinicalResultBlo
 <div
   className="clinical-result blood-pressure-result truncated"
 >
-  <div
-    className="decorated-result-display truncated"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display truncated"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
+          }
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;
 
@@ -1154,63 +1266,65 @@ exports[`ClinicalResultBloodPressure should render a truncated ClinicalResultBlo
 <div
   className="clinical-result blood-pressure-result truncated"
 >
-  <div
-    className="decorated-result-display truncated"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display truncated"
     >
-      <InjectIntl(BloodPressureDisplay)
-        diastolicUnit="mmhg"
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.1",
-            "isModified": true,
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "180",
-            },
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-111.1"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        id="111"
-        result={
-          Object {
-            "cleanedUnit": "mmhg",
-            "eventId": "111.2",
-            "isModified": true,
-            "noData": false,
-            "result": Object {
-              "unit": "mmHg",
-              "value": "80",
-            },
+        <InjectIntl(BloodPressureDisplay)
+          diastolicUnit="mmhg"
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.1",
+              "isModified": true,
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "180",
+              },
+            }
           }
-        }
-        type="Diastolic"
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-111.1"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          id="111"
+          result={
+            Object {
+              "cleanedUnit": "mmhg",
+              "eventId": "111.2",
+              "isModified": true,
+              "noData": false,
+              "result": Object {
+                "unit": "mmHg",
+                "value": "80",
+              },
+            }
+          }
+          type="Diastolic"
+        />
+      </div>
+      <IconModified
+        a11yLabel="Terra.clinicalResult.resultModified"
+        className="icon-modified"
+        focusable="true"
+        role="img"
+        viewBox="0 0 48 48"
+        xmlns="http://www.w3.org/2000/svg"
       />
     </div>
-    <IconModified
-      a11yLabel="Terra.clinicalResult.resultModified"
-      className="icon-modified"
-      focusable="true"
-      role="img"
-      viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg"
-    />
-  </div>
+  </span>
 </div>
 `;
 
@@ -1218,57 +1332,59 @@ exports[`ClinicalResultBloodPressure should render systolic and diastolic with n
 <div
   className="clinical-result blood-pressure-result"
 >
-  <div
-    className="decorated-result-display"
-  >
+  <span>
     <div
-      className="result-display"
+      className="decorated-result-display"
     >
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        result={
-          Object {
-            "eventId": "",
-            "hasComment": false,
-            "interpretation": "normal",
-            "isModified": false,
-            "isUnverified": false,
-            "noData": true,
-            "result": Object {
-              "unit": "",
-              "value": null,
-            },
-            "resultNoData": true,
-          }
-        }
-        type="Systolic"
-      />
-      <span
-        className="result-display-separator"
-        key="Observation-Separator-"
+      <div
+        className="result-display"
       >
-        /
-      </span>
-      <InjectIntl(BloodPressureDisplay)
-        hideUnit={false}
-        result={
-          Object {
-            "eventId": "",
-            "hasComment": false,
-            "interpretation": "normal",
-            "isModified": false,
-            "isUnverified": false,
-            "noData": true,
-            "result": Object {
-              "unit": "",
-              "value": null,
-            },
-            "resultNoData": true,
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          result={
+            Object {
+              "eventId": "",
+              "hasComment": false,
+              "interpretation": "normal",
+              "isModified": false,
+              "isUnverified": false,
+              "noData": true,
+              "result": Object {
+                "unit": "",
+                "value": null,
+              },
+              "resultNoData": true,
+            }
           }
-        }
-        type="Diastolic"
-      />
+          type="Systolic"
+        />
+        <span
+          className="result-display-separator"
+          key="Observation-Separator-"
+        >
+          /
+        </span>
+        <InjectIntl(BloodPressureDisplay)
+          hideUnit={false}
+          result={
+            Object {
+              "eventId": "",
+              "hasComment": false,
+              "interpretation": "normal",
+              "isModified": false,
+              "isUnverified": false,
+              "noData": true,
+              "result": Object {
+                "unit": "",
+                "value": null,
+              },
+              "resultNoData": true,
+            }
+          }
+          type="Diastolic"
+        />
+      </div>
     </div>
-  </div>
+  </span>
 </div>
 `;

--- a/packages/terra-clinical-result/translations/de.json
+++ b/packages/terra-clinical-result/translations/de.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positiv",
   "Terra.clinicalResult.interpretationAbnormal": "Abnorm",
   "Terra.clinicalResult.interpretationHigh": "Hoch",
-  "Terra.clinicalResult.interpretationLow": "Niedrig"
+  "Terra.clinicalResult.interpretationLow": "Niedrig",
+  "Terra.clinicalResult.bloodPressure": "Blutdruck"
 }

--- a/packages/terra-clinical-result/translations/en-AU.json
+++ b/packages/terra-clinical-result/translations/en-AU.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positive",
   "Terra.clinicalResult.interpretationAbnormal": "Abnormal",
   "Terra.clinicalResult.interpretationHigh": "High",
-  "Terra.clinicalResult.interpretationLow": "Low"
+  "Terra.clinicalResult.interpretationLow": "Low",
+  "Terra.clinicalResult.bloodPressure": "Blood Pressure"
 }

--- a/packages/terra-clinical-result/translations/en-CA.json
+++ b/packages/terra-clinical-result/translations/en-CA.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positive",
   "Terra.clinicalResult.interpretationAbnormal": "Abnormal",
   "Terra.clinicalResult.interpretationHigh": "High",
-  "Terra.clinicalResult.interpretationLow": "Low"
+  "Terra.clinicalResult.interpretationLow": "Low",
+  "Terra.clinicalResult.bloodPressure": "Blood Pressure"
 }

--- a/packages/terra-clinical-result/translations/en-GB.json
+++ b/packages/terra-clinical-result/translations/en-GB.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positive",
   "Terra.clinicalResult.interpretationAbnormal": "Abnormal",
   "Terra.clinicalResult.interpretationHigh": "High",
-  "Terra.clinicalResult.interpretationLow": "Low"
+  "Terra.clinicalResult.interpretationLow": "Low",
+  "Terra.clinicalResult.bloodPressure": "Blood Pressure"
 }

--- a/packages/terra-clinical-result/translations/en-US.json
+++ b/packages/terra-clinical-result/translations/en-US.json
@@ -18,5 +18,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positive",
   "Terra.clinicalResult.interpretationAbnormal": "Abnormal",
   "Terra.clinicalResult.interpretationHigh": "High",
-  "Terra.clinicalResult.interpretationLow": "Low"
+  "Terra.clinicalResult.interpretationLow": "Low",
+  "Terra.clinicalResult.bloodPressure": "Blood Pressure"
 }

--- a/packages/terra-clinical-result/translations/en.json
+++ b/packages/terra-clinical-result/translations/en.json
@@ -20,5 +20,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positive",
   "Terra.clinicalResult.interpretationAbnormal": "Abnormal",
   "Terra.clinicalResult.interpretationHigh": "High",
-  "Terra.clinicalResult.interpretationLow": "Low"
+  "Terra.clinicalResult.interpretationLow": "Low",
+  "Terra.clinicalResult.bloodPressure": "Blood Pressure"
 }

--- a/packages/terra-clinical-result/translations/es-ES.json
+++ b/packages/terra-clinical-result/translations/es-ES.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positivo",
   "Terra.clinicalResult.interpretationAbnormal": "Anómalo",
   "Terra.clinicalResult.interpretationHigh": "Alto",
-  "Terra.clinicalResult.interpretationLow": "Bajo"
+  "Terra.clinicalResult.interpretationLow": "Bajo",
+  "Terra.clinicalResult.bloodPressure": "Presión arterial"
 }

--- a/packages/terra-clinical-result/translations/es-US.json
+++ b/packages/terra-clinical-result/translations/es-US.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positivo",
   "Terra.clinicalResult.interpretationAbnormal": "Anómalo",
   "Terra.clinicalResult.interpretationHigh": "Alto",
-  "Terra.clinicalResult.interpretationLow": "Bajo"
+  "Terra.clinicalResult.interpretationLow": "Bajo",
+  "Terra.clinicalResult.bloodPressure": "Presión arterial"
 }

--- a/packages/terra-clinical-result/translations/es.json
+++ b/packages/terra-clinical-result/translations/es.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positivo",
   "Terra.clinicalResult.interpretationAbnormal": "Anómalo",
   "Terra.clinicalResult.interpretationHigh": "Alto",
-  "Terra.clinicalResult.interpretationLow": "Bajo"
+  "Terra.clinicalResult.interpretationLow": "Bajo",
+  "Terra.clinicalResult.bloodPressure": "Presión arterial"
 }

--- a/packages/terra-clinical-result/translations/fi-FI.json
+++ b/packages/terra-clinical-result/translations/fi-FI.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positive",
   "Terra.clinicalResult.interpretationAbnormal": "Abnormal",
   "Terra.clinicalResult.interpretationHigh": "High",
-  "Terra.clinicalResult.interpretationLow": "Low"
+  "Terra.clinicalResult.interpretationLow": "Low",
+  "Terra.clinicalResult.bloodPressure": "Blood Pressure"
 }

--- a/packages/terra-clinical-result/translations/fr-FR.json
+++ b/packages/terra-clinical-result/translations/fr-FR.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positif",
   "Terra.clinicalResult.interpretationAbnormal": "Anormal",
   "Terra.clinicalResult.interpretationHigh": "Élevée",
-  "Terra.clinicalResult.interpretationLow": "Faible"
+  "Terra.clinicalResult.interpretationLow": "Faible",
+  "Terra.clinicalResult.bloodPressure": "Pression artérielle"
 }

--- a/packages/terra-clinical-result/translations/fr.json
+++ b/packages/terra-clinical-result/translations/fr.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positif",
   "Terra.clinicalResult.interpretationAbnormal": "Anormal",
   "Terra.clinicalResult.interpretationHigh": "Élevée",
-  "Terra.clinicalResult.interpretationLow": "Faible"
+  "Terra.clinicalResult.interpretationLow": "Faible",
+  "Terra.clinicalResult.bloodPressure": "Pression artérielle"
 }

--- a/packages/terra-clinical-result/translations/nl-BE.json
+++ b/packages/terra-clinical-result/translations/nl-BE.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positief",
   "Terra.clinicalResult.interpretationAbnormal": "Afwijkend",
   "Terra.clinicalResult.interpretationHigh": "Hoog",
-  "Terra.clinicalResult.interpretationLow": "Laag"
+  "Terra.clinicalResult.interpretationLow": "Laag",
+  "Terra.clinicalResult.bloodPressure": "Bloeddruk"
 }

--- a/packages/terra-clinical-result/translations/nl.json
+++ b/packages/terra-clinical-result/translations/nl.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positief",
   "Terra.clinicalResult.interpretationAbnormal": "Afwijkend",
   "Terra.clinicalResult.interpretationHigh": "Hoog",
-  "Terra.clinicalResult.interpretationLow": "Laag"
+  "Terra.clinicalResult.interpretationLow": "Laag",
+  "Terra.clinicalResult.bloodPressure": "Bloeddruk"
 }

--- a/packages/terra-clinical-result/translations/pt-BR.json
+++ b/packages/terra-clinical-result/translations/pt-BR.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positivo",
   "Terra.clinicalResult.interpretationAbnormal": "Anormal",
   "Terra.clinicalResult.interpretationHigh": "Alto",
-  "Terra.clinicalResult.interpretationLow": "Baixo"
+  "Terra.clinicalResult.interpretationLow": "Baixo",
+  "Terra.clinicalResult.bloodPressure": "Pressão sanguínea"
 }

--- a/packages/terra-clinical-result/translations/pt.json
+++ b/packages/terra-clinical-result/translations/pt.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positivo",
   "Terra.clinicalResult.interpretationAbnormal": "Anormal",
   "Terra.clinicalResult.interpretationHigh": "Alto",
-  "Terra.clinicalResult.interpretationLow": "Baixo"
+  "Terra.clinicalResult.interpretationLow": "Baixo",
+  "Terra.clinicalResult.bloodPressure": "Pressão sanguínea"
 }

--- a/packages/terra-clinical-result/translations/sv-SE.json
+++ b/packages/terra-clinical-result/translations/sv-SE.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positiv",
   "Terra.clinicalResult.interpretationAbnormal": "Onormalt",
   "Terra.clinicalResult.interpretationHigh": "Högt",
-  "Terra.clinicalResult.interpretationLow": "Lågt"
+  "Terra.clinicalResult.interpretationLow": "Lågt",
+  "Terra.clinicalResult.bloodPressure": "Blodtryck"
 }

--- a/packages/terra-clinical-result/translations/sv.json
+++ b/packages/terra-clinical-result/translations/sv.json
@@ -17,5 +17,6 @@
   "Terra.clinicalResult.interpretationPositive": "Positiv",
   "Terra.clinicalResult.interpretationAbnormal": "Onormalt",
   "Terra.clinicalResult.interpretationHigh": "Högt",
-  "Terra.clinicalResult.interpretationLow": "Lågt"
+  "Terra.clinicalResult.interpretationLow": "Lågt",
+  "Terra.clinicalResult.bloodPressure": "Blodtryck"
 }


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
When we have additional displays (concept, DateTime) as part of blood pressure results, we will need to restructure them so that the screen reader understands them as a group.

**What was changed:**
* A new prop was added to allow the consumers to make the blood pressure to be grouped. When the prop is set to true, the blood pressure results will be understood as a group. The group name/label is set to "Blood Pressure {dateTime}". 

**Why it was changed:**
When there are additional displays along with the blood pressure results, the accessibility tooling can recognize the cell as a group context.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

When the prop is false:

https://github.com/cerner/terra-clinical/assets/55503680/6dbf8784-2222-4199-b432-66bc5b68f36f

When the prop is true:

https://github.com/cerner/terra-clinical/assets/55503680/ffd2efde-6d7b-4ae0-bd17-6cd7876c7245


### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9096

---

Thank you for contributing to Terra.
@cerner/terra
