### PR TITLE
[terra-clinical-result] Add alt text for strikethroughs to be understood as entered in error

### DIFF
--- a/packages/terra-clinical-result/CHANGELOG.md
+++ b/packages/terra-clinical-result/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Added screen-reader support for clinical-result icons. (Requires Jest test updates on consuming applications)
   * Added screen-reader support for alternative text for when no results are returned.
   * Added screen-reader support for clinical-result FlowsheetResultCell EnteredInError.
+  * Added screen-reader support for strikethroughs to convey an entered in error status.
 
 ## 1.16.0 - (March 29, 2023)
 

--- a/packages/terra-clinical-result/src/_BloodPressureDisplay.jsx
+++ b/packages/terra-clinical-result/src/_BloodPressureDisplay.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
+import VisuallyHiddenText from 'terra-visually-hidden-text';
 import observationPropShape from './proptypes/observationPropTypes';
 import Observation from './common/observation/_Observation';
 import ResultError from './common/other/_ResultError';
@@ -27,6 +29,11 @@ const propTypes = {
    * The cleaned unit of the diastolic display.
    */
   diastolicUnit: PropTypes.string,
+  /**
+   * @private
+   * The intl object to be injected for translations.
+   */
+  intl: PropTypes.shape({ formatMessage: PropTypes.func }).isRequired,
 };
 
 const BloodPressureDisplay = ({
@@ -35,7 +42,10 @@ const BloodPressureDisplay = ({
   id,
   type,
   diastolicUnit,
+  intl,
 }) => {
+  const isValidValue = result?.result?.value;
+
   if (!result) {
     return <ResultError key={`Error-${type}-${id}`} />;
   }
@@ -46,7 +56,20 @@ const BloodPressureDisplay = ({
     <ConditionalWrapper
       key={`del-${type}-${result.eventId}`}
       condition={result.statusInError}
-      wrapper={children => <del>{children}</del>}
+      wrapper={children => (
+        <span>
+          <s aria-hidden="true">{children}</s>
+          {isValidValue
+            ? (
+              <VisuallyHiddenText text={intl.formatMessage(
+                { id: 'Terra.clinicalResult.statusInErrorStrikethrough' },
+                { strikethroughResult: `${result.result.value} ${!hideUnit && result.result.unit ? result.result.unit : ''}` },
+              )}
+              />
+            )
+            : null}
+        </span>
+      )}
     >
       <Observation
         key={`Observation-${type}-${result.eventId}`}
@@ -62,4 +85,4 @@ const BloodPressureDisplay = ({
 
 BloodPressureDisplay.propTypes = propTypes;
 
-export default BloodPressureDisplay;
+export default injectIntl(BloodPressureDisplay);

--- a/packages/terra-clinical-result/src/_BloodPressureDisplay.jsx
+++ b/packages/terra-clinical-result/src/_BloodPressureDisplay.jsx
@@ -45,6 +45,7 @@ const BloodPressureDisplay = ({
   intl,
 }) => {
   const isValidValue = result?.result?.value;
+  const isUnitPresent = !hideUnit && result.result.unit;
 
   if (!result) {
     return <ResultError key={`Error-${type}-${id}`} />;
@@ -63,7 +64,7 @@ const BloodPressureDisplay = ({
             ? (
               <VisuallyHiddenText text={intl.formatMessage(
                 { id: 'Terra.clinicalResult.statusInErrorStrikethrough' },
-                { strikethroughResult: `${result.result.value} ${!hideUnit && result.result.unit ? result.result.unit : ''}` },
+                { strikethroughResult: `${result.result.value} ${isUnitPresent ? result.result.unit : ''}` },
               )}
               />
             )

--- a/packages/terra-clinical-result/src/_BloodPressureDisplay.jsx
+++ b/packages/terra-clinical-result/src/_BloodPressureDisplay.jsx
@@ -45,7 +45,7 @@ const BloodPressureDisplay = ({
   intl,
 }) => {
   const isValidValue = result?.result?.value;
-  const isUnitPresent = !hideUnit && result.result.unit;
+  const isUnitPresent = !hideUnit && result?.result?.unit;
 
   if (!result) {
     return <ResultError key={`Error-${type}-${id}`} />;

--- a/packages/terra-clinical-result/src/_ClinicalResultDisplay.jsx
+++ b/packages/terra-clinical-result/src/_ClinicalResultDisplay.jsx
@@ -88,6 +88,7 @@ const ClinicalResultDisplay = ({
   intl,
 }) => {
   const isValidValue = result?.value;
+  const isUnitPresent = !hideUnit && result.unit;
   const isStatusInError = !isEmpty(status) ? checkIsStatusInError(status) : false;
   const decoratedResultClassnames = cx([
     'decorated-result-display',
@@ -108,7 +109,7 @@ const ClinicalResultDisplay = ({
                   ? (
                     <VisuallyHiddenText text={intl.formatMessage(
                       { id: 'Terra.clinicalResult.statusInErrorStrikethrough' },
-                      { strikethroughResult: `${result.value} ${!hideUnit && result.unit ? result.unit : ''}` },
+                      { strikethroughResult: `${result.value} ${isUnitPresent ? result.unit : ''}` },
                     )}
                     />
                   )

--- a/packages/terra-clinical-result/src/_ClinicalResultDisplay.jsx
+++ b/packages/terra-clinical-result/src/_ClinicalResultDisplay.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
+import { injectIntl } from 'react-intl';
+import VisuallyHiddenText from 'terra-visually-hidden-text';
 import statusPropType from './proptypes/statusPropTypes';
 import interpretationPropType from './proptypes/interpretationPropTypes';
 import valueQuantityPropType from './proptypes/valuePropTypes';
@@ -63,6 +65,11 @@ const propTypes = {
    * Used by Flowsheet Result Cell to hide icons because it displays them in different positions.
    */
   hideAccessoryDisplays: PropTypes.bool,
+  /**
+   * @private
+   * The intl object to be injected for translations.
+   */
+  intl: PropTypes.shape({ formatMessage: PropTypes.func }).isRequired,
 };
 
 const ClinicalResultDisplay = ({
@@ -78,7 +85,9 @@ const ClinicalResultDisplay = ({
   hasComment,
   conceptDisplay,
   datetimeDisplay,
+  intl,
 }) => {
+  const isValidValue = result?.value;
   const isStatusInError = !isEmpty(status) ? checkIsStatusInError(status) : false;
   const decoratedResultClassnames = cx([
     'decorated-result-display',
@@ -92,7 +101,20 @@ const ClinicalResultDisplay = ({
           <ConditionalWrapper
             key={`del-Observation-${eventId}`}
             condition={isStatusInError}
-            wrapper={children => <del>{children}</del>}
+            wrapper={children => (
+              <span>
+                <s aria-hidden="true">{children}</s>
+                {isValidValue
+                  ? (
+                    <VisuallyHiddenText text={intl.formatMessage(
+                      { id: 'Terra.clinicalResult.statusInErrorStrikethrough' },
+                      { strikethroughResult: `${result.value} ${!hideUnit && result.unit ? result.unit : ''}` },
+                    )}
+                    />
+                  )
+                  : null}
+              </span>
+            )}
           >
             <Observation
               key={`Observation-${eventId}`}
@@ -114,4 +136,4 @@ const ClinicalResultDisplay = ({
 
 ClinicalResultDisplay.propTypes = propTypes;
 
-export default ClinicalResultDisplay;
+export default injectIntl(ClinicalResultDisplay);

--- a/packages/terra-clinical-result/src/common/other/_EnteredInError.jsx
+++ b/packages/terra-clinical-result/src/common/other/_EnteredInError.jsx
@@ -40,7 +40,7 @@ const EnteredInError = (props) => {
       <span aria-hidden="true">
         {intl.formatMessage({ id: 'Terra.clinicalResult.statusInError' })}
       </span>
-      <VisuallyHiddenText text={intl.formatMessage({ id: 'Terra.clinicalResult.statusInErrorAria' })} />
+      <VisuallyHiddenText text={intl.formatMessage({ id: 'Terra.clinicalResult.statusInErrorHiddenText' })} />
     </span>
   );
 };

--- a/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result-blood-pressure/EnteredInErrorClinicalResultBloodPressureHiddenUnit.test.jsx
+++ b/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result-blood-pressure/EnteredInErrorClinicalResultBloodPressureHiddenUnit.test.jsx
@@ -6,6 +6,7 @@ const resultData = {
     eventId: '111.1',
     result: {
       value: '180',
+      unit: 'mmHg',
     },
     status: 'entered-in-error',
   },
@@ -13,13 +14,14 @@ const resultData = {
     eventId: '111.1',
     result: {
       value: '80',
+      unit: 'mmHg',
     },
     status: 'entered-in-error',
   },
 };
 
 const ClinicalResultBloodPressureExample = () => (
-  <ClinicalResultBloodPressure {...resultData} />
+  <ClinicalResultBloodPressure {...resultData} hideUnit />
 );
 
 export default ClinicalResultBloodPressureExample;

--- a/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result-blood-pressure/EnteredInErrorClinicalResultBloodPressureNoUnit.test.jsx
+++ b/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result-blood-pressure/EnteredInErrorClinicalResultBloodPressureNoUnit.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { ClinicalResultBloodPressure } from 'terra-clinical-result/lib/index';
+
+const resultData = {
+  systolic: {
+    eventId: '111.1',
+    result: {
+      value: '180',
+      unit: 'mmHg',
+    },
+    status: 'entered-in-error',
+  },
+  diastolic: {
+    eventId: '111.1',
+    result: {
+      value: '80',
+      unit: 'mmHg',
+    },
+    status: 'entered-in-error',
+  },
+};
+
+const ClinicalResultBloodPressureExample = () => (
+  <ClinicalResultBloodPressure {...resultData} hideUnit hasComment />
+);
+
+export default ClinicalResultBloodPressureExample;

--- a/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result-blood-pressure/EnteredInErrorClinicalResultBloodPressurePartial.test.jsx
+++ b/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result-blood-pressure/EnteredInErrorClinicalResultBloodPressurePartial.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ClinicalResultBloodPressure } from 'terra-clinical-result/lib/index';
+
+const resultData = {
+  systolic: {
+    eventId: '111.1',
+    result: {
+      value: '180',
+      unit: 'mmHg',
+    },
+    status: 'entered-in-error',
+  },
+  diastolic: {
+    eventId: '111.1',
+    result: {
+      value: '80',
+      unit: 'mmHg',
+    },
+  },
+};
+
+const ClinicalResultBloodPressureExample = () => (
+  <ClinicalResultBloodPressure {...resultData} />
+);
+
+export default ClinicalResultBloodPressureExample;

--- a/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result/EnteredInErrorResultHiddenUnit.test.jsx
+++ b/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result/EnteredInErrorResultHiddenUnit.test.jsx
@@ -5,11 +5,13 @@ const enteredInErrorResultValue = {
   eventId: '111',
   result: {
     value: '12345.678',
+    unit: 'mL',
   },
   status: 'entered-in-error',
   interpretation: 'critical',
   conceptDisplay: 'Temperature Oral',
   datetimeDisplay: 'Nov 23, 2019 13:31:31',
+  hideUnit: true,
 };
 
 export default () => <ClinicalResult {...enteredInErrorResultValue} />;

--- a/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result/EnteredInErrorResultNoUnit.test.jsx
+++ b/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result/EnteredInErrorResultNoUnit.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ClinicalResult from 'terra-clinical-result/lib/index';
+
+const enteredInErrorResultValue = {
+  eventId: '111',
+  result: {
+    value: '12345.678',
+    unit: 'mL',
+  },
+  status: 'entered-in-error',
+  interpretation: 'critical',
+  conceptDisplay: 'Temperature Oral',
+  datetimeDisplay: 'Nov 23, 2019 13:31:31',
+  hideUnit: true,
+};
+
+export default () => <ClinicalResult {...enteredInErrorResultValue} />;

--- a/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result/EnteredInErrorResultWithUnit.test.jsx
+++ b/packages/terra-clinical-result/src/terra-dev-site/test/clinical-result/clinical-result/EnteredInErrorResultWithUnit.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ClinicalResult from 'terra-clinical-result/lib/index';
+
+const enteredInErrorResultValue = {
+  eventId: '111',
+  result: {
+    value: '12345.678',
+    unit: 'mL',
+  },
+  status: 'entered-in-error',
+  interpretation: 'critical',
+  conceptDisplay: 'Temperature Oral',
+  datetimeDisplay: 'Nov 23, 2019 13:31:31',
+};
+
+export default () => <ClinicalResult {...enteredInErrorResultValue} />;

--- a/packages/terra-clinical-result/tests/jest/_BloodPressureDisplay.test.jsx
+++ b/packages/terra-clinical-result/tests/jest/_BloodPressureDisplay.test.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+/* eslint-disable-next-line import/no-extraneous-dependencies */
+import { shallowWithIntl } from 'terra-enzyme-intl';
 import BloodPressureDisplay from '../../src/_BloodPressureDisplay';
 import { DefaultBloodPressureResult } from '../../src/terra-dev-site/test/clinical-result/TestResults';
 
@@ -15,12 +17,12 @@ describe('BloodPressureDisplay', () => {
   const type = 'Systolic';
 
   it('should render a default BloodPressureDisplay', () => {
-    const display = shallow(<BloodPressureDisplay result={defaultResult} id={id} type={type} />);
+    const display = shallowWithIntl(<BloodPressureDisplay result={defaultResult} id={id} type={type} />).dive();
     expect(display).toMatchSnapshot();
   });
 
   it('should render a ResultError', () => {
-    const display = shallow(<BloodPressureDisplay id={id} type={type} />);
+    const display = shallowWithIntl(<BloodPressureDisplay id={id} type={type} />).dive();
     expect(display).toMatchSnapshot();
   });
 
@@ -29,7 +31,7 @@ describe('BloodPressureDisplay', () => {
       ...defaultResult,
       noData: true,
     };
-    const display = shallow(<BloodPressureDisplay result={result} id={id} type={type} />);
+    const display = shallowWithIntl(<BloodPressureDisplay result={result} id={id} type={type} />).dive();
     expect(display).toMatchSnapshot();
   });
 
@@ -39,17 +41,17 @@ describe('BloodPressureDisplay', () => {
       statusInError: true,
       interpretation: 'critical',
     };
-    const display = shallow(<BloodPressureDisplay result={result} id={id} type={type} />);
+    const display = shallowWithIntl(<BloodPressureDisplay result={result} id={id} type={type} />).dive();
     expect(display).toMatchSnapshot();
   });
 
   it('should hide the unit if hideUnit is true', () => {
-    const display = shallow(<BloodPressureDisplay result={defaultResult} id={id} type={type} hideUnit />);
+    const display = shallowWithIntl(<BloodPressureDisplay result={defaultResult} id={id} type={type} hideUnit />).dive();
     expect(display).toMatchSnapshot();
   });
 
   it('should hide the unit if data\'s cleanedUnit is equal to diastolicUnit prop', () => {
-    const display = shallow(<BloodPressureDisplay result={defaultResult} id={id} type={type} diastolicUnit={defaultResult.cleanedUnit} />);
+    const display = shallowWithIntl(<BloodPressureDisplay result={defaultResult} id={id} type={type} diastolicUnit={defaultResult.cleanedUnit} />).dive();
     expect(display).toMatchSnapshot();
   });
 
@@ -59,7 +61,7 @@ describe('BloodPressureDisplay', () => {
       statusInError: true,
       interpretation: 'critical',
     };
-    const display = shallow(<BloodPressureDisplay result={result} id={id} type={type} diastolicUnit={defaultResult.cleanedUnit} />);
+    const display = shallowWithIntl(<BloodPressureDisplay result={result} id={id} type={type} diastolicUnit={defaultResult.cleanedUnit} />).dive();
     expect(display).toMatchSnapshot();
   });
 });

--- a/packages/terra-clinical-result/tests/jest/_ClinicalResultDisplay.test.jsx
+++ b/packages/terra-clinical-result/tests/jest/_ClinicalResultDisplay.test.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
+/* eslint-disable-next-line import/no-extraneous-dependencies */
+import { shallowWithIntl } from 'terra-enzyme-intl';
 import ClinicalResultDisplay from '../../src/_ClinicalResultDisplay';
 import DefaultResult from '../../src/terra-dev-site/test/clinical-result/TestResults';
 
 describe('ClinicalResultDisplay', () => {
   it('should render a default ClinicalResultDisplay', () => {
-    const result = shallow(<ClinicalResultDisplay {...DefaultResult} />);
+    const result = shallowWithIntl(<ClinicalResultDisplay {...DefaultResult} />).dive();
     expect(result).toMatchSnapshot();
   });
 
   it('should render a truncated ClinicalResultDisplay', () => {
-    const result = shallow(<ClinicalResultDisplay {...DefaultResult} isTruncated />);
+    const result = shallowWithIntl(<ClinicalResultDisplay {...DefaultResult} isTruncated />).dive();
     expect(result).toMatchSnapshot();
   });
 
@@ -17,7 +19,7 @@ describe('ClinicalResultDisplay', () => {
     const resultData = {
       ...DefaultResult,
     };
-    const result = shallow(<ClinicalResultDisplay {...resultData} isTruncated isModified />);
+    const result = shallowWithIntl(<ClinicalResultDisplay {...resultData} isTruncated isModified />).dive();
     expect(result).toMatchSnapshot();
   });
 
@@ -26,7 +28,7 @@ describe('ClinicalResultDisplay', () => {
       ...DefaultResult,
       interpretation: 'critical',
     };
-    const result = shallow(<ClinicalResultDisplay {...resultData} hideUnit />);
+    const result = shallowWithIntl(<ClinicalResultDisplay {...resultData} hideUnit />).dive();
     expect(result).toMatchSnapshot();
   });
 
@@ -34,7 +36,7 @@ describe('ClinicalResultDisplay', () => {
     const resultData = {
       ...DefaultResult,
     };
-    const result = shallow(<ClinicalResultDisplay {...resultData} isModified />);
+    const result = shallowWithIntl(<ClinicalResultDisplay {...resultData} isModified />).dive();
     expect(result).toMatchSnapshot();
   });
 
@@ -42,7 +44,7 @@ describe('ClinicalResultDisplay', () => {
     const resultData = {
       ...DefaultResult,
     };
-    const result = shallow(<ClinicalResultDisplay {...resultData} hasComment />);
+    const result = shallowWithIntl(<ClinicalResultDisplay {...resultData} hasComment />).dive();
     expect(result).toMatchSnapshot();
   });
 
@@ -50,7 +52,7 @@ describe('ClinicalResultDisplay', () => {
     const resultData = {
       ...DefaultResult,
     };
-    const result = shallow(<ClinicalResultDisplay {...resultData} isUnverified />);
+    const result = shallowWithIntl(<ClinicalResultDisplay {...resultData} isUnverified />).dive();
     expect(result).toMatchSnapshot();
   });
 
@@ -58,7 +60,7 @@ describe('ClinicalResultDisplay', () => {
     const resultData = {
       ...DefaultResult,
     };
-    const result = shallow(<ClinicalResultDisplay {...resultData} hideUnit />);
+    const result = shallowWithIntl(<ClinicalResultDisplay {...resultData} hideUnit />).dive();
     expect(result).toMatchSnapshot();
   });
 
@@ -67,7 +69,7 @@ describe('ClinicalResultDisplay', () => {
       ...DefaultResult,
       conceptDisplay: 'Temperature Oral',
     };
-    const result = shallow(<ClinicalResultDisplay {...resultData} />);
+    const result = shallowWithIntl(<ClinicalResultDisplay {...resultData} />).dive();
     expect(result).toMatchSnapshot();
   });
 
@@ -76,17 +78,17 @@ describe('ClinicalResultDisplay', () => {
       ...DefaultResult,
       datetimeDisplay: 'Nov 23, 2019 13:31:31',
     };
-    const result = shallow(<ClinicalResultDisplay {...resultData} />);
+    const result = shallowWithIntl(<ClinicalResultDisplay {...resultData} />).dive();
     expect(result).toMatchSnapshot();
   });
 
-  it('should render a entered-in-error status result', () => {
+  it('should render an entered-in-error status result', () => {
     const resultData = {
       ...DefaultResult,
       status: 'entered-in-error',
       interpretation: 'critical',
     };
-    const result = shallow(<ClinicalResultDisplay {...resultData} />);
+    const result = shallowWithIntl(<ClinicalResultDisplay {...resultData} />).shallow();
     expect(result).toMatchSnapshot();
   });
 });

--- a/packages/terra-clinical-result/tests/jest/__snapshots__/ClinicalResult.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/__snapshots__/ClinicalResult.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`ClinicalResult correctly applies the theme context className 1`] = `
 <div
   className="clinical-result orion-fusion-theme"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     eventId="111"
     result={
       Object {
@@ -20,7 +20,7 @@ exports[`ClinicalResult should pass certain props to Observation  1`] = `
 <div
   className="clinical-result"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     eventId="111"
     hideUnit={true}
     interpretation="critical"
@@ -54,7 +54,7 @@ exports[`ClinicalResult should render a commented result  1`] = `
 <div
   className="clinical-result"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     eventId="111"
     hasComment={true}
     result={
@@ -71,7 +71,7 @@ exports[`ClinicalResult should render a default ClinicalResult 1`] = `
 <div
   className="clinical-result"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     eventId="111"
     result={
       Object {
@@ -87,7 +87,7 @@ exports[`ClinicalResult should render a entered-in-error status result 1`] = `
 <div
   className="clinical-result"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     eventId="111"
     interpretation="critical"
     result={
@@ -105,7 +105,7 @@ exports[`ClinicalResult should render a modified result  1`] = `
 <div
   className="clinical-result"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     eventId="111"
     isModified={true}
     result={
@@ -122,7 +122,7 @@ exports[`ClinicalResult should render a result with a concept display 1`] = `
 <div
   className="clinical-result"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     conceptDisplay="Temperature Oral"
     eventId="111"
     result={
@@ -139,7 +139,7 @@ exports[`ClinicalResult should render a result with a date time display 1`] = `
 <div
   className="clinical-result"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     datetimeDisplay="Nov 23, 2019 13:31:31"
     eventId="111"
     result={
@@ -156,7 +156,7 @@ exports[`ClinicalResult should render a result with unit hidden 1`] = `
 <div
   className="clinical-result"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     eventId="111"
     hideUnit={true}
     result={
@@ -173,7 +173,7 @@ exports[`ClinicalResult should render a truncated ClinicalResult 1`] = `
 <div
   className="clinical-result truncated"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     eventId="111"
     isTruncated={true}
     result={
@@ -190,7 +190,7 @@ exports[`ClinicalResult should render a truncated ClinicalResult with icons move
 <div
   className="clinical-result truncated"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     eventId="111"
     isModified={true}
     isTruncated={true}
@@ -208,7 +208,7 @@ exports[`ClinicalResult should render an unverified result  1`] = `
 <div
   className="clinical-result"
 >
-  <ClinicalResultDisplay
+  <InjectIntl(ClinicalResultDisplay)
     eventId="111"
     isUnverified={true}
     result={

--- a/packages/terra-clinical-result/tests/jest/__snapshots__/ClinicalResultBloodPressure.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/__snapshots__/ClinicalResultBloodPressure.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should pass certain props to 
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={true}
         id="111"
@@ -23,7 +23,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should pass certain props to 
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={true}
         id="111"
         result={
@@ -55,7 +55,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a commented res
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         id="111"
@@ -68,7 +68,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a commented res
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -110,7 +110,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a entered-in-er
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         id="111"
@@ -123,7 +123,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a entered-in-er
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -157,7 +157,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a modified resu
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         id="111"
@@ -170,7 +170,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a modified resu
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -210,7 +210,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a result with a
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         id="111"
@@ -223,7 +223,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a result with a
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -261,7 +261,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a result with a
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         id="111"
@@ -274,7 +274,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a result with a
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -312,7 +312,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a result with u
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={true}
         id="111"
@@ -325,7 +325,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render a result with u
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={true}
         id="111"
         result={
@@ -356,7 +356,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render an unverified r
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         id="111"
@@ -369,7 +369,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render an unverified r
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -409,7 +409,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render diastolic with 
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         result={
           Object {
@@ -430,7 +430,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render diastolic with 
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         result={
           Object {
@@ -464,7 +464,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render with error 1`] 
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         result={
           Object {
@@ -485,7 +485,7 @@ exports[`ClinicalResultBloodPressure - Diastolic - should render with error 1`] 
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         result={Object {}}
         type="Diastolic"
@@ -505,7 +505,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should pass certain props to O
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={true}
         id="111"
         result={
@@ -528,7 +528,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should pass certain props to O
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={true}
         id="111"
         result={Object {}}
@@ -549,7 +549,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a commented resu
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -572,7 +572,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a commented resu
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={Object {}}
@@ -603,7 +603,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a entered-in-err
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -628,7 +628,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a entered-in-err
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={Object {}}
@@ -649,7 +649,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a modified resul
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -672,7 +672,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a modified resul
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={Object {}}
@@ -701,7 +701,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a result with a 
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -725,7 +725,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a result with a 
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={Object {}}
@@ -751,7 +751,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a result with a 
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -775,7 +775,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a result with a 
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={Object {}}
@@ -801,7 +801,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a result with un
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={true}
         id="111"
         result={
@@ -823,7 +823,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render a result with un
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={true}
         id="111"
         result={Object {}}
@@ -844,7 +844,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render an unverified re
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -867,7 +867,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render an unverified re
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={Object {}}
@@ -896,7 +896,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render with error 1`] =
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         result={Object {}}
@@ -908,7 +908,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render with error 1`] =
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         result={
           Object {
@@ -938,7 +938,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render with no data 1`]
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         result={
@@ -964,7 +964,7 @@ exports[`ClinicalResultBloodPressure - Systolic - should render with no data 1`]
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         result={
           Object {
@@ -994,7 +994,7 @@ exports[`ClinicalResultBloodPressure correctly applies the theme context classNa
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         id="111"
@@ -1017,7 +1017,7 @@ exports[`ClinicalResultBloodPressure correctly applies the theme context classNa
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -1052,7 +1052,7 @@ exports[`ClinicalResultBloodPressure should render a default ClinicalResultBlood
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         id="111"
@@ -1075,7 +1075,7 @@ exports[`ClinicalResultBloodPressure should render a default ClinicalResultBlood
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -1106,7 +1106,7 @@ exports[`ClinicalResultBloodPressure should render a truncated ClinicalResultBlo
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         id="111"
@@ -1129,7 +1129,7 @@ exports[`ClinicalResultBloodPressure should render a truncated ClinicalResultBlo
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -1160,7 +1160,7 @@ exports[`ClinicalResultBloodPressure should render a truncated ClinicalResultBlo
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         diastolicUnit="mmhg"
         hideUnit={false}
         id="111"
@@ -1184,7 +1184,7 @@ exports[`ClinicalResultBloodPressure should render a truncated ClinicalResultBlo
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         id="111"
         result={
@@ -1224,7 +1224,7 @@ exports[`ClinicalResultBloodPressure should render systolic and diastolic with n
     <div
       className="result-display"
     >
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         result={
           Object {
@@ -1249,7 +1249,7 @@ exports[`ClinicalResultBloodPressure should render systolic and diastolic with n
       >
         /
       </span>
-      <BloodPressureDisplay
+      <InjectIntl(BloodPressureDisplay)
         hideUnit={false}
         result={
           Object {

--- a/packages/terra-clinical-result/tests/jest/__snapshots__/_ClinicalResultDisplay.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/__snapshots__/_ClinicalResultDisplay.test.jsx.snap
@@ -97,38 +97,6 @@ exports[`ClinicalResultDisplay should render a default ClinicalResultDisplay 1`]
 </Fragment>
 `;
 
-exports[`ClinicalResultDisplay should render a entered-in-error status result 1`] = `
-<Fragment>
-  <div
-    className="decorated-result-display status-in-error"
-  >
-    <div
-      className="result-display"
-    >
-      <ConditionalWrapper
-        condition={true}
-        key="del-Observation-111"
-        wrapper={[Function]}
-      >
-        <InjectIntl(Observation)
-          eventId="111"
-          interpretation={null}
-          key="Observation-111"
-          result={
-            Object {
-              "unit": "mL",
-              "value": "12345.678",
-            }
-          }
-        />
-      </ConditionalWrapper>
-      <InjectIntl(Icons) />
-    </div>
-  </div>
-  <SecondaryDisplays />
-</Fragment>
-`;
-
 exports[`ClinicalResultDisplay should render a modified result  1`] = `
 <Fragment>
   <div
@@ -319,6 +287,38 @@ exports[`ClinicalResultDisplay should render a truncated ClinicalResultDisplay w
     <InjectIntl(Icons)
       isModified={true}
     />
+  </div>
+  <SecondaryDisplays />
+</Fragment>
+`;
+
+exports[`ClinicalResultDisplay should render an entered-in-error status result 1`] = `
+<Fragment>
+  <div
+    className="decorated-result-display status-in-error"
+  >
+    <div
+      className="result-display"
+    >
+      <ConditionalWrapper
+        condition={true}
+        key="del-Observation-111"
+        wrapper={[Function]}
+      >
+        <InjectIntl(Observation)
+          eventId="111"
+          interpretation={null}
+          key="Observation-111"
+          result={
+            Object {
+              "unit": "mL",
+              "value": "12345.678",
+            }
+          }
+        />
+      </ConditionalWrapper>
+      <InjectIntl(Icons) />
+    </div>
   </div>
   <SecondaryDisplays />
 </Fragment>

--- a/packages/terra-clinical-result/tests/jest/common/other/EnteredInError.test.jsx
+++ b/packages/terra-clinical-result/tests/jest/common/other/EnteredInError.test.jsx
@@ -6,7 +6,7 @@ import EnteredInError from '../../../../src/common/other/_EnteredInError';
 describe('EnteredInError', () => {
   it('should render a default EnteredInError', () => {
     const result = shallowWithIntl(<EnteredInError />).dive();
-    expect(result.find('VisuallyHiddenText').at(0).prop('text')).toEqual('Terra.clinicalResult.statusInErrorAria');
+    expect(result.find('VisuallyHiddenText').at(0).prop('text')).toEqual('Terra.clinicalResult.statusInErrorHiddenText');
     expect(result).toMatchSnapshot();
   });
 });

--- a/packages/terra-clinical-result/tests/jest/common/other/__snapshots__/EnteredInError.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/common/other/__snapshots__/EnteredInError.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`EnteredInError should render a default EnteredInError 1`] = `
     Terra.clinicalResult.statusInError
   </span>
   <VisuallyHiddenText
-    text="Terra.clinicalResult.statusInErrorAria"
+    text="Terra.clinicalResult.statusInErrorHiddenText"
   />
 </span>
 `;

--- a/packages/terra-clinical-result/translations/de.json
+++ b/packages/terra-clinical-result/translations/de.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Fehler",
   "Terra.clinicalResult.statusInError": "Ungültig",
-  "Terra.clinicalResult.statusInErrorAria": "Wert für ungültig erklärt ",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Wert für ungültig erklärt ",
   "Terra.clinicalResult.selectToViewAria": "Zum Anzeigen weiterer Details auswählen",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Ergebnis enthält weitere Werte",
   "Terra.clinicalResult.viewResults": "Ergebnisse anzeigen",

--- a/packages/terra-clinical-result/translations/en-AU.json
+++ b/packages/terra-clinical-result/translations/en-AU.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
-  "Terra.clinicalResult.statusInErrorAria": "Value Unrecorded as In Error",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Value Unrecorded as In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",
   "Terra.clinicalResult.viewResults": "View Results",

--- a/packages/terra-clinical-result/translations/en-CA.json
+++ b/packages/terra-clinical-result/translations/en-CA.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
-  "Terra.clinicalResult.statusInErrorAria": "Value Uncharted as In Error",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Value Uncharted as In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",
   "Terra.clinicalResult.viewResults": "View Results",

--- a/packages/terra-clinical-result/translations/en-GB.json
+++ b/packages/terra-clinical-result/translations/en-GB.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
-  "Terra.clinicalResult.statusInErrorAria": "Value Unrecorded as In Error",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Value Unrecorded as In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",
   "Terra.clinicalResult.viewResults": "View Results",

--- a/packages/terra-clinical-result/translations/en-US.json
+++ b/packages/terra-clinical-result/translations/en-US.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
   "Terra.clinicalResult.statusInErrorAria": "Value Uncharted as In Error",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Result {strikethroughResult} Entered In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",
   "Terra.clinicalResult.viewResults": "View Results",

--- a/packages/terra-clinical-result/translations/en-US.json
+++ b/packages/terra-clinical-result/translations/en-US.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
-  "Terra.clinicalResult.statusInErrorAria": "Value Uncharted as In Error",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Value Uncharted as In Error",
   "Terra.clinicalResult.statusInErrorStrikethrough": "Result {strikethroughResult} Entered In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",

--- a/packages/terra-clinical-result/translations/en.json
+++ b/packages/terra-clinical-result/translations/en.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
   "Terra.clinicalResult.statusInErrorAria": "Value Uncharted as In Error",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Result {strikethroughResult} Entered In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",
   "Terra.clinicalResult.viewResults": "View Results",

--- a/packages/terra-clinical-result/translations/en.json
+++ b/packages/terra-clinical-result/translations/en.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
-  "Terra.clinicalResult.statusInErrorAria": "Value Uncharted as In Error",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Value Uncharted as In Error",
   "Terra.clinicalResult.statusInErrorStrikethrough": "Result {strikethroughResult} Entered In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",

--- a/packages/terra-clinical-result/translations/es-ES.json
+++ b/packages/terra-clinical-result/translations/es-ES.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "Con errores",
-  "Terra.clinicalResult.statusInErrorAria": "El valor no se ha documentado como Con errores",
+  "Terra.clinicalResult.statusInErrorHiddenText": "El valor no se ha documentado como Con errores",
   "Terra.clinicalResult.selectToViewAria": "Seleccione para ver más detalles",
   "Terra.clinicalResult.includesAdditionalValuesAria": "El resultado incluye valores adicionales",
   "Terra.clinicalResult.viewResults": "Ver resultados",

--- a/packages/terra-clinical-result/translations/es-US.json
+++ b/packages/terra-clinical-result/translations/es-US.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "Con errores",
-  "Terra.clinicalResult.statusInErrorAria": "El valor no se ha documentado como Con errores",
+  "Terra.clinicalResult.statusInErrorHiddenText": "El valor no se ha documentado como Con errores",
   "Terra.clinicalResult.selectToViewAria": "Seleccione para ver más detalles",
   "Terra.clinicalResult.includesAdditionalValuesAria": "El resultado incluye valores adicionales",
   "Terra.clinicalResult.viewResults": "Ver resultados",

--- a/packages/terra-clinical-result/translations/es.json
+++ b/packages/terra-clinical-result/translations/es.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "Con errores",
-  "Terra.clinicalResult.statusInErrorAria": "El valor no se ha documentado como Con errores",
+  "Terra.clinicalResult.statusInErrorHiddenText": "El valor no se ha documentado como Con errores",
   "Terra.clinicalResult.selectToViewAria": "Seleccione para ver más detalles",
   "Terra.clinicalResult.includesAdditionalValuesAria": "El resultado incluye valores adicionales",
   "Terra.clinicalResult.viewResults": "Ver resultados",

--- a/packages/terra-clinical-result/translations/fi-FI.json
+++ b/packages/terra-clinical-result/translations/fi-FI.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
-  "Terra.clinicalResult.statusInErrorAria": "Value Uncharted as In Error",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Value Uncharted as In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",
   "Terra.clinicalResult.viewResults": "View Results",

--- a/packages/terra-clinical-result/translations/fr-FR.json
+++ b/packages/terra-clinical-result/translations/fr-FR.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Erreur",
   "Terra.clinicalResult.statusInError": "En erreur",
-  "Terra.clinicalResult.statusInErrorAria": "Valeur archivée avec le statut En erreur ",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Valeur archivée avec le statut En erreur ",
   "Terra.clinicalResult.selectToViewAria": "Sélectionnez pour afficher plus de détails.",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Le résultat inclut des valeurs supplémentaires.",
   "Terra.clinicalResult.viewResults": "Afficher les résultats",

--- a/packages/terra-clinical-result/translations/fr.json
+++ b/packages/terra-clinical-result/translations/fr.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Erreur",
   "Terra.clinicalResult.statusInError": "En erreur",
-  "Terra.clinicalResult.statusInErrorAria": "Valeur archivée avec le statut En erreur ",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Valeur archivée avec le statut En erreur ",
   "Terra.clinicalResult.selectToViewAria": "Sélectionnez pour afficher plus de détails.",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Le résultat inclut des valeurs supplémentaires.",
   "Terra.clinicalResult.viewResults": "Afficher les résultats",

--- a/packages/terra-clinical-result/translations/nl-BE.json
+++ b/packages/terra-clinical-result/translations/nl-BE.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Fout",
   "Terra.clinicalResult.statusInError": "Fout",
-  "Terra.clinicalResult.statusInErrorAria": "Geschrapt als Fout beschouwen",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Geschrapt als Fout beschouwen",
   "Terra.clinicalResult.selectToViewAria": "Selecteer om meer details te bekijken",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Resultaat bevat aanvullende waarden",
   "Terra.clinicalResult.viewResults": "Resultaten weergeven",

--- a/packages/terra-clinical-result/translations/nl.json
+++ b/packages/terra-clinical-result/translations/nl.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Fout",
   "Terra.clinicalResult.statusInError": "Fout",
-  "Terra.clinicalResult.statusInErrorAria": "Geschrapt als Fout beschouwen",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Geschrapt als Fout beschouwen",
   "Terra.clinicalResult.selectToViewAria": "Selecteer om meer details te bekijken",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Resultaat bevat aanvullende waarden",
   "Terra.clinicalResult.viewResults": "Resultaten weergeven",

--- a/packages/terra-clinical-result/translations/pt-BR.json
+++ b/packages/terra-clinical-result/translations/pt-BR.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Erro",
   "Terra.clinicalResult.statusInError": "Em erro",
-  "Terra.clinicalResult.statusInErrorAria": "Valor não documentado como Com erro",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Valor não documentado como Com erro",
   "Terra.clinicalResult.selectToViewAria": "Selecione para visualizar mais detalhes",
   "Terra.clinicalResult.includesAdditionalValuesAria": "O resultado inclui valores adicionais",
   "Terra.clinicalResult.viewResults": "Visualizar resultados",

--- a/packages/terra-clinical-result/translations/pt.json
+++ b/packages/terra-clinical-result/translations/pt.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Erro",
   "Terra.clinicalResult.statusInError": "Em erro",
-  "Terra.clinicalResult.statusInErrorAria": "Valor não documentado como Com erro",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Valor não documentado como Com erro",
   "Terra.clinicalResult.selectToViewAria": "Selecione para visualizar mais detalhes",
   "Terra.clinicalResult.includesAdditionalValuesAria": "O resultado inclui valores adicionais",
   "Terra.clinicalResult.viewResults": "Visualizar resultados",

--- a/packages/terra-clinical-result/translations/sv-SE.json
+++ b/packages/terra-clinical-result/translations/sv-SE.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Fel",
   "Terra.clinicalResult.statusInError": "Felaktig",
-  "Terra.clinicalResult.statusInErrorAria": "Värdet togs bort eftersom det var felaktigt",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Värdet togs bort eftersom det var felaktigt",
   "Terra.clinicalResult.selectToViewAria": "Välj för att visa fler uppgifter.",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Resultatet innehåller fler värden",
   "Terra.clinicalResult.viewResults": "Visa resultat",

--- a/packages/terra-clinical-result/translations/sv.json
+++ b/packages/terra-clinical-result/translations/sv.json
@@ -1,7 +1,7 @@
 {
   "Terra.clinicalResult.resultError": "Fel",
   "Terra.clinicalResult.statusInError": "Felaktig",
-  "Terra.clinicalResult.statusInErrorAria": "Värdet togs bort eftersom det var felaktigt",
+  "Terra.clinicalResult.statusInErrorHiddenText": "Värdet togs bort eftersom det var felaktigt",
   "Terra.clinicalResult.selectToViewAria": "Välj för att visa fler uppgifter.",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Resultatet innehåller fler värden",
   "Terra.clinicalResult.viewResults": "Visa resultat",


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
When we have a result with a strikethrough that means to the visual user that the result has been deleted in some way, in our case that it has been entered in error. We need to convey a message that tells the screenreader user that the result is no longer relevant and has been 'Entered in error'. That message would look like "Result {someResult} Entered In Error". Note: translations for this message are still being figured out.

**What was changed:**

The initial strikethrough result is now aria-hidden and instead of using "< del>" we'll be using a regular strikethrough "< s>". This is so the screenreader doesn't read out 'deleted' along with the result and instead just reads out our custom message. 
Then a visually hidden text element has been added to the conditional wrapper after the strikethrough element for the result. To populate the text in that visually hidden element I opted to directly use the [result](https://github.com/cerner/terra-clinical/blob/main/packages/terra-clinical-result/src/_ClinicalResultDisplay.jsx#L100) being passed in and not the children. The children in this case are what observation will return, which is an [object containing up to two spans](https://github.com/cerner/terra-clinical/blob/main/packages/terra-clinical-result/src/common/observation/_Observation.jsx#L99-L106)(the unit span is optional). We don't need the spans, just their text and the [result.value and result.unit](https://github.com/cerner/terra-clinical/blob/main/packages/terra-clinical-result/src/common/observation/_Observation.jsx#L104C11-L106) is what's populating those anyway. 

To use the result directly, before rendering the hidden text I added a check for if the result.value is valid using the same logic as [here](https://github.com/cerner/terra-clinical/blob/main/packages/terra-clinical-result/src/common/observation/_Observation.jsx#L76). I also added a check for if the unit exists, like [this](https://github.com/cerner/terra-clinical/blob/main/packages/terra-clinical-result/src/common/observation/_Observation.jsx#L106) as well as a check for if hideUnit is set to true (in which case we don't want to read out the unit even if it exists).

If the result value is not valid then we just return null and do not render the visually hidden text at all. This is because in the observation file when the result value isn't valid it returns a [result error](https://github.com/cerner/terra-clinical/blob/main/packages/terra-clinical-result/src/common/observation/_Observation.jsx#L110) so we don't want to read out anything extra if that's the case. 


**Why it was changed:**
When there is a strikethrough it's currently reading out the result and that it's been deleted but that's not consistent among all the browsers/tools. We also want to give greater context to the strikethrough result and the fact that it is not just deleted but entered in error. Lots of discussion has gone on about what the exact messaging should be, but we think we've landed on the current string I mentioned in the summary - more info can be found in the comments of the jira tied to this PR. 

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9067<!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra

Clinical Result:

https://github.com/cerner/terra-clinical/assets/40574651/c5b939bb-66f0-41f9-b250-1d0b3d59612f


Clinical Result Blood Pressure:

https://github.com/cerner/terra-clinical/assets/40574651/74865bdc-3a53-4148-8381-21c7379b473b

