### PR TITLE
[terra-clinical-result] Update ResultTimeHeaderCell to use <time> html tags

### DIFF
--- a/packages/terra-clinical-result/CHANGELOG.md
+++ b/packages/terra-clinical-result/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 * Added
   * Added screen-reader support for strikethroughs to convey an entered in error status.
-  * Added additonal translations for strikethrough alt text.
+  * Added additional translations for strikethrough alt text.
 
 * Fixed
   * Fixed a check related to Clinical Result strikethrough alt text for if a result unit exists or not.
 
 * Changed
   * Changed FlowsheetResultCell, ResultNameHeaderCell and ResultTimeHeaderCell in clinical-result to use proper semantic html.
+  * Updated ResultTimeHeaderCell component to use `<time>` html tags for the date and time.
 
 ## 1.17.0 - (June 14, 2023)
 

--- a/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
+++ b/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import classNamesBind from 'classnames/bind';
 import ThemeContext from 'terra-theme-context';
+import VisuallyHiddenText from 'terra-visually-hidden-text';
 import styles from './ResultTimeHeaderCell.module.scss';
 
 const cx = classNamesBind.bind(styles);
@@ -62,7 +63,7 @@ const ResultTimeHeaderCell = (props) => {
       className={timeHeaderCellClassnames}
     >
       <time className={dateClassnames}>{date}</time>
-      <p className={cx('hidden-space')}>{'\u00A0'}</p>
+      <VisuallyHiddenText className={cx('hidden-space')} text={'\u00A0'} />
       <time className={cx('time')}>{time}</time>
     </th>
   );

--- a/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
+++ b/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
@@ -62,6 +62,7 @@ const ResultTimeHeaderCell = (props) => {
       className={timeHeaderCellClassnames}
     >
       <time className={dateClassnames}>{date}</time>
+      <p className={cx('hidden-space')}>{'\u00A0'}</p>
       <time className={cx('time')}>{time}</time>
     </th>
   );

--- a/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
+++ b/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
@@ -63,7 +63,7 @@ const ResultTimeHeaderCell = (props) => {
       className={timeHeaderCellClassnames}
     >
       <time className={dateClassnames}>{date}</time>
-      <VisuallyHiddenText className={cx('hidden-space')} text={'\u00A0'} />
+      <VisuallyHiddenText text={'\u00A0'} />
       <time className={cx('time')}>{time}</time>
     </th>
   );

--- a/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
+++ b/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
@@ -9,7 +9,7 @@ const cx = classNamesBind.bind(styles);
 
 const propTypes = {
   /**
-   * Content to be displayed on the first line, typically abbrivated date, e.g. `Dec 12, 2010`
+   * Content to be displayed on the first line, typically abbreviated date, e.g. `Dec 12, 2010`
    */
   date: PropTypes.string.isRequired,
   /**
@@ -61,8 +61,8 @@ const ResultTimeHeaderCell = (props) => {
       {...customProps}
       className={timeHeaderCellClassnames}
     >
-      <div className={dateClassnames}>{date}</div>
-      <div className={cx('time')}>{time}</div>
+      <time className={dateClassnames}>{date}</time>
+      <time className={cx('time')}>{time}</time>
     </th>
   );
 };

--- a/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.module.scss
+++ b/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.module.scss
@@ -39,8 +39,12 @@
       min-width: 10px; // Needed for IE10
     }
 
+    .hidden-space {
+      display: none;
+    }
+
     /* stylelint-disable-next-line selector-max-compound-selectors */
-    .date + .time {
+    .hidden-space + .time {
       margin-top: var(--terra-clinical-result-time-header-cell-time-margin-top, 0.14285em); // Must use ems for font scaling
     }
   }

--- a/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.module.scss
+++ b/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.module.scss
@@ -34,14 +34,10 @@
       font-size: var(--terra-clinical-result-time-header-cell-time-font-size, 1em); // Must use ems for font scaling
       font-weight: var(--terra-clinical-result-time-header-cell-time-font-weight, 400);
       line-height: var(--terra-clinical-result-time-header-cell-time-line-height, 1.14285);
+      margin-top: var(--terra-clinical-result-time-header-cell-time-margin-top, 0.14285em); // Must use ems for font scaling
       max-width: 100%;
       min-height: var(--terra-clinical-result-time-header-cell-time-min-height, 1.14285em); // Set to same as line-height in ems
       min-width: 10px; // Needed for IE10
-    }
-
-    /* stylelint-disable-next-line selector-max-compound-selectors */
-    .hidden-space + .time {
-      margin-top: var(--terra-clinical-result-time-header-cell-time-margin-top, 0.14285em); // Must use ems for font scaling
     }
   }
 

--- a/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.module.scss
+++ b/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.module.scss
@@ -39,10 +39,6 @@
       min-width: 10px; // Needed for IE10
     }
 
-    .hidden-space {
-      display: none;
-    }
-
     /* stylelint-disable-next-line selector-max-compound-selectors */
     .hidden-space + .time {
       margin-top: var(--terra-clinical-result-time-header-cell-time-margin-top, 0.14285em); // Must use ems for font scaling

--- a/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
@@ -10,7 +10,6 @@ exports[`ResultTimeHeaderCell correctly applies the theme context className 1`] 
     December 31st 1999
   </time>
   <VisuallyHiddenText
-    className="hidden-space"
     text=" "
   />
   <time
@@ -31,7 +30,6 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with compact 1`] = `
     December 31st 1999
   </time>
   <VisuallyHiddenText
-    className="hidden-space"
     text=" "
   />
   <time
@@ -52,7 +50,6 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with none 1`] = `
     December 31st 1999
   </time>
   <VisuallyHiddenText
-    className="hidden-space"
     text=" "
   />
   <time
@@ -73,7 +70,6 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with standard 1`] = `
     December 31st 1999
   </time>
   <VisuallyHiddenText
-    className="hidden-space"
     text=" "
   />
   <time
@@ -94,7 +90,6 @@ exports[`ResultTimeHeaderCell should hide date 1`] = `
     December 31st 1999
   </time>
   <VisuallyHiddenText
-    className="hidden-space"
     text=" "
   />
   <time
@@ -115,7 +110,6 @@ exports[`ResultTimeHeaderCell should render a date and time 1`] = `
     December 31st 1999
   </time>
   <VisuallyHiddenText
-    className="hidden-space"
     text=" "
   />
   <time

--- a/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
@@ -9,6 +9,11 @@ exports[`ResultTimeHeaderCell correctly applies the theme context className 1`] 
   >
     December 31st 1999
   </time>
+  <p
+    className="hidden-space"
+  >
+     
+  </p>
   <time
     className="time"
   >
@@ -26,6 +31,11 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with compact 1`] = `
   >
     December 31st 1999
   </time>
+  <p
+    className="hidden-space"
+  >
+     
+  </p>
   <time
     className="time"
   >
@@ -43,6 +53,11 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with none 1`] = `
   >
     December 31st 1999
   </time>
+  <p
+    className="hidden-space"
+  >
+     
+  </p>
   <time
     className="time"
   >
@@ -60,6 +75,11 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with standard 1`] = `
   >
     December 31st 1999
   </time>
+  <p
+    className="hidden-space"
+  >
+     
+  </p>
   <time
     className="time"
   >
@@ -77,6 +97,11 @@ exports[`ResultTimeHeaderCell should hide date 1`] = `
   >
     December 31st 1999
   </time>
+  <p
+    className="hidden-space"
+  >
+     
+  </p>
   <time
     className="time"
   >
@@ -94,6 +119,11 @@ exports[`ResultTimeHeaderCell should render a date and time 1`] = `
   >
     December 31st 1999
   </time>
+  <p
+    className="hidden-space"
+  >
+     
+  </p>
   <time
     className="time"
   >

--- a/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
@@ -9,11 +9,10 @@ exports[`ResultTimeHeaderCell correctly applies the theme context className 1`] 
   >
     December 31st 1999
   </time>
-  <p
+  <VisuallyHiddenText
     className="hidden-space"
-  >
-     
-  </p>
+    text=" "
+  />
   <time
     className="time"
   >
@@ -31,11 +30,10 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with compact 1`] = `
   >
     December 31st 1999
   </time>
-  <p
+  <VisuallyHiddenText
     className="hidden-space"
-  >
-     
-  </p>
+    text=" "
+  />
   <time
     className="time"
   >
@@ -53,11 +51,10 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with none 1`] = `
   >
     December 31st 1999
   </time>
-  <p
+  <VisuallyHiddenText
     className="hidden-space"
-  >
-     
-  </p>
+    text=" "
+  />
   <time
     className="time"
   >
@@ -75,11 +72,10 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with standard 1`] = `
   >
     December 31st 1999
   </time>
-  <p
+  <VisuallyHiddenText
     className="hidden-space"
-  >
-     
-  </p>
+    text=" "
+  />
   <time
     className="time"
   >
@@ -97,11 +93,10 @@ exports[`ResultTimeHeaderCell should hide date 1`] = `
   >
     December 31st 1999
   </time>
-  <p
+  <VisuallyHiddenText
     className="hidden-space"
-  >
-     
-  </p>
+    text=" "
+  />
   <time
     className="time"
   >
@@ -119,11 +114,10 @@ exports[`ResultTimeHeaderCell should render a date and time 1`] = `
   >
     December 31st 1999
   </time>
-  <p
+  <VisuallyHiddenText
     className="hidden-space"
-  >
-     
-  </p>
+    text=" "
+  />
   <time
     className="time"
   >

--- a/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
@@ -4,16 +4,16 @@ exports[`ResultTimeHeaderCell correctly applies the theme context className 1`] 
 <th
   className="clinical-result-time-header-cell padding-compact orion-fusion-theme"
 >
-  <div
+  <time
     className="date"
   >
     December 31st 1999
-  </div>
-  <div
+  </time>
+  <time
     className="time"
   >
     10:00 PM
-  </div>
+  </time>
 </th>
 `;
 
@@ -21,16 +21,16 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with compact 1`] = `
 <th
   className="clinical-result-time-header-cell padding-compact"
 >
-  <div
+  <time
     className="date"
   >
     December 31st 1999
-  </div>
-  <div
+  </time>
+  <time
     className="time"
   >
     10:00 PM
-  </div>
+  </time>
 </th>
 `;
 
@@ -38,16 +38,16 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with none 1`] = `
 <th
   className="clinical-result-time-header-cell"
 >
-  <div
+  <time
     className="date"
   >
     December 31st 1999
-  </div>
-  <div
+  </time>
+  <time
     className="time"
   >
     10:00 PM
-  </div>
+  </time>
 </th>
 `;
 
@@ -55,16 +55,16 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with standard 1`] = `
 <th
   className="clinical-result-time-header-cell padding-standard"
 >
-  <div
+  <time
     className="date"
   >
     December 31st 1999
-  </div>
-  <div
+  </time>
+  <time
     className="time"
   >
     10:00 PM
-  </div>
+  </time>
 </th>
 `;
 
@@ -72,16 +72,16 @@ exports[`ResultTimeHeaderCell should hide date 1`] = `
 <th
   className="clinical-result-time-header-cell padding-compact"
 >
-  <div
+  <time
     className="date hide-date"
   >
     December 31st 1999
-  </div>
-  <div
+  </time>
+  <time
     className="time"
   >
     10:00 PM
-  </div>
+  </time>
 </th>
 `;
 
@@ -89,15 +89,15 @@ exports[`ResultTimeHeaderCell should render a date and time 1`] = `
 <th
   className="clinical-result-time-header-cell padding-compact"
 >
-  <div
+  <time
     className="date"
   >
     December 31st 1999
-  </div>
-  <div
+  </time>
+  <time
     className="time"
   >
     10:00 PM
-  </div>
+  </time>
 </th>
 `;


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
Updated the ResultTimeHeaderCell component to use `<time>` html tags for the date and time.

**What was changed:**
The ResultTimeHeaderCell component is now using `<time>` html tags for the date and time rather than divs. I also added a visually hidden space between the date and time to resolve an issue with JAWS combining the two and reading them incorrectly.

**Why it was changed:**
So the date and time are read to screen reader users in an understandable way.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

#### Visual Testing

https://github.com/cerner/terra-clinical/assets/37230460/c6919048-2add-4467-95ba-f1e237f99889

https://github.com/cerner/terra-clinical/assets/37230460/532209a2-267f-4fb8-8fb0-1c837d759fac

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [x] UX review
- [x] Accessibility review
- [ ] Functional review

### Additional Details
Voiceover and JAWS do not officially support the `<time>` html tag yet, so neither of them read both the date and time %100 correctly.

**This PR resolves:**

UXPLATFORM-9077 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
