### PR TITLE
[terra-clinical-result] Add optional chaining operator to clinical result display and update translations

### DIFF
--- a/packages/terra-clinical-result/CHANGELOG.md
+++ b/packages/terra-clinical-result/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Added
   * Added screen-reader support for strikethroughs to convey an entered in error status.
+  * Added additonal translations for strikethrough alt text.
+
+* Fixed
+  * Fixed the clincial result display check for if the unit is valid when reading alt text for strikethroughs.
 
 ## 1.17.0 - (June 14, 2023)
 

--- a/packages/terra-clinical-result/CHANGELOG.md
+++ b/packages/terra-clinical-result/CHANGELOG.md
@@ -7,7 +7,7 @@
   * Added additonal translations for strikethrough alt text.
 
 * Fixed
-  * Fixed the clincial result display check for if the unit is valid when reading alt text for strikethroughs.
+  * Fixed a check related to Clinical Result strikethrough alt text for if a result unit exists or not.
 
 ## 1.17.0 - (June 14, 2023)
 

--- a/packages/terra-clinical-result/src/_ClinicalResultDisplay.jsx
+++ b/packages/terra-clinical-result/src/_ClinicalResultDisplay.jsx
@@ -88,7 +88,7 @@ const ClinicalResultDisplay = ({
   intl,
 }) => {
   const isValidValue = result?.value;
-  const isUnitPresent = !hideUnit && result.unit;
+  const isUnitPresent = !hideUnit && result?.unit;
   const isStatusInError = !isEmpty(status) ? checkIsStatusInError(status) : false;
   const decoratedResultClassnames = cx([
     'decorated-result-display',

--- a/packages/terra-clinical-result/tests/jest/ClinicalResult.test.jsx
+++ b/packages/terra-clinical-result/tests/jest/ClinicalResult.test.jsx
@@ -62,6 +62,17 @@ describe('ClinicalResult', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('should render a result with no unit', () => {
+    const resultData = {
+      eventId: '111',
+      result: {
+        value: '12345.678',
+      },
+    };
+    const result = shallow(<ClinicalResult {...resultData} />);
+    expect(result).toMatchSnapshot();
+  });
+
   it('should render a result with a concept display', () => {
     const resultData = {
       ...DefaultResult,

--- a/packages/terra-clinical-result/tests/jest/ClinicalResult.test.jsx
+++ b/packages/terra-clinical-result/tests/jest/ClinicalResult.test.jsx
@@ -106,6 +106,13 @@ describe('ClinicalResult', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('should not render visually hidden alt text for strikethroughs when result is undefined', () => {
+    const resultData = undefined;
+    const result = shallow(<ClinicalResult {...resultData} />);
+    expect(result.find('VisuallyHiddenText').exists()).toBeFalsy();
+    expect(result).toMatchSnapshot();
+  });
+
   it('should render a NoData if hasResultNoData is true', () => {
     const result = shallow(<ClinicalResult hasResultNoData />);
     expect(result).toMatchSnapshot();

--- a/packages/terra-clinical-result/tests/jest/__snapshots__/ClinicalResult.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/__snapshots__/ClinicalResult.test.jsx.snap
@@ -16,6 +16,14 @@ exports[`ClinicalResult correctly applies the theme context className 1`] = `
 </div>
 `;
 
+exports[`ClinicalResult should not render visually hidden alt text for strikethroughs when result is undefined 1`] = `
+<div
+  className="clinical-result"
+>
+  <InjectIntl(ClinicalResultDisplay) />
+</div>
+`;
+
 exports[`ClinicalResult should pass certain props to Observation  1`] = `
 <div
   className="clinical-result"

--- a/packages/terra-clinical-result/tests/jest/__snapshots__/ClinicalResult.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/__snapshots__/ClinicalResult.test.jsx.snap
@@ -152,6 +152,21 @@ exports[`ClinicalResult should render a result with a date time display 1`] = `
 </div>
 `;
 
+exports[`ClinicalResult should render a result with no unit 1`] = `
+<div
+  className="clinical-result"
+>
+  <InjectIntl(ClinicalResultDisplay)
+    eventId="111"
+    result={
+      Object {
+        "value": "12345.678",
+      }
+    }
+  />
+</div>
+`;
+
 exports[`ClinicalResult should render a result with unit hidden 1`] = `
 <div
   className="clinical-result"

--- a/packages/terra-clinical-result/translations/de.json
+++ b/packages/terra-clinical-result/translations/de.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Fehler",
   "Terra.clinicalResult.statusInError": "Ungültig",
   "Terra.clinicalResult.statusInErrorHiddenText": "Wert für ungültig erklärt ",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Ergebnis {strikethroughResult} versehentlich eingegeben",
   "Terra.clinicalResult.selectToViewAria": "Zum Anzeigen weiterer Details auswählen",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Ergebnis enthält weitere Werte",
   "Terra.clinicalResult.viewResults": "Ergebnisse anzeigen",

--- a/packages/terra-clinical-result/translations/en-AU.json
+++ b/packages/terra-clinical-result/translations/en-AU.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
   "Terra.clinicalResult.statusInErrorHiddenText": "Value Unrecorded as In Error",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Result {strikethroughResult} Entered In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",
   "Terra.clinicalResult.viewResults": "View Results",

--- a/packages/terra-clinical-result/translations/en-CA.json
+++ b/packages/terra-clinical-result/translations/en-CA.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
   "Terra.clinicalResult.statusInErrorHiddenText": "Value Uncharted as In Error",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Result {strikethroughResult} Entered In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",
   "Terra.clinicalResult.viewResults": "View Results",

--- a/packages/terra-clinical-result/translations/en-GB.json
+++ b/packages/terra-clinical-result/translations/en-GB.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
   "Terra.clinicalResult.statusInErrorHiddenText": "Value Unrecorded as In Error",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Result {strikethroughResult} Entered In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",
   "Terra.clinicalResult.viewResults": "View Results",

--- a/packages/terra-clinical-result/translations/es-ES.json
+++ b/packages/terra-clinical-result/translations/es-ES.json
@@ -2,7 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "Con errores",
   "Terra.clinicalResult.statusInErrorHiddenText": "El valor no se ha documentado como Con errores",
-  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultado {strikethroughResult}escrito Con errores",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultado {strikethroughResult} escrito Con errores",
   "Terra.clinicalResult.selectToViewAria": "Seleccione para ver más detalles",
   "Terra.clinicalResult.includesAdditionalValuesAria": "El resultado incluye valores adicionales",
   "Terra.clinicalResult.viewResults": "Ver resultados",

--- a/packages/terra-clinical-result/translations/es-ES.json
+++ b/packages/terra-clinical-result/translations/es-ES.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "Con errores",
   "Terra.clinicalResult.statusInErrorHiddenText": "El valor no se ha documentado como Con errores",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultado {strikethroughResult}escrito Con errores",
   "Terra.clinicalResult.selectToViewAria": "Seleccione para ver más detalles",
   "Terra.clinicalResult.includesAdditionalValuesAria": "El resultado incluye valores adicionales",
   "Terra.clinicalResult.viewResults": "Ver resultados",

--- a/packages/terra-clinical-result/translations/es-US.json
+++ b/packages/terra-clinical-result/translations/es-US.json
@@ -2,7 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "Con errores",
   "Terra.clinicalResult.statusInErrorHiddenText": "El valor no se ha documentado como Con errores",
-  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultado {strikethroughResult}escrito Con errores",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultado {strikethroughResult} escrito Con errores",
   "Terra.clinicalResult.selectToViewAria": "Seleccione para ver más detalles",
   "Terra.clinicalResult.includesAdditionalValuesAria": "El resultado incluye valores adicionales",
   "Terra.clinicalResult.viewResults": "Ver resultados",

--- a/packages/terra-clinical-result/translations/es-US.json
+++ b/packages/terra-clinical-result/translations/es-US.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "Con errores",
   "Terra.clinicalResult.statusInErrorHiddenText": "El valor no se ha documentado como Con errores",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultado {strikethroughResult}escrito Con errores",
   "Terra.clinicalResult.selectToViewAria": "Seleccione para ver más detalles",
   "Terra.clinicalResult.includesAdditionalValuesAria": "El resultado incluye valores adicionales",
   "Terra.clinicalResult.viewResults": "Ver resultados",

--- a/packages/terra-clinical-result/translations/es.json
+++ b/packages/terra-clinical-result/translations/es.json
@@ -2,7 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "Con errores",
   "Terra.clinicalResult.statusInErrorHiddenText": "El valor no se ha documentado como Con errores",
-  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultado {strikethroughResult}escrito Con errores",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultado {strikethroughResult} escrito Con errores",
   "Terra.clinicalResult.selectToViewAria": "Seleccione para ver más detalles",
   "Terra.clinicalResult.includesAdditionalValuesAria": "El resultado incluye valores adicionales",
   "Terra.clinicalResult.viewResults": "Ver resultados",

--- a/packages/terra-clinical-result/translations/es.json
+++ b/packages/terra-clinical-result/translations/es.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "Con errores",
   "Terra.clinicalResult.statusInErrorHiddenText": "El valor no se ha documentado como Con errores",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultado {strikethroughResult}escrito Con errores",
   "Terra.clinicalResult.selectToViewAria": "Seleccione para ver más detalles",
   "Terra.clinicalResult.includesAdditionalValuesAria": "El resultado incluye valores adicionales",
   "Terra.clinicalResult.viewResults": "Ver resultados",

--- a/packages/terra-clinical-result/translations/fi-FI.json
+++ b/packages/terra-clinical-result/translations/fi-FI.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Error",
   "Terra.clinicalResult.statusInError": "In Error",
   "Terra.clinicalResult.statusInErrorHiddenText": "Value Uncharted as In Error",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Result {strikethroughResult} Entered In Error",
   "Terra.clinicalResult.selectToViewAria": "Select to view more details",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Result includes additional values",
   "Terra.clinicalResult.viewResults": "View Results",

--- a/packages/terra-clinical-result/translations/fr-FR.json
+++ b/packages/terra-clinical-result/translations/fr-FR.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Erreur",
   "Terra.clinicalResult.statusInError": "En erreur",
   "Terra.clinicalResult.statusInErrorHiddenText": "Valeur archivée avec le statut En erreur ",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Saisie erronée du résultat {strikethroughResult}",
   "Terra.clinicalResult.selectToViewAria": "Sélectionnez pour afficher plus de détails.",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Le résultat inclut des valeurs supplémentaires.",
   "Terra.clinicalResult.viewResults": "Afficher les résultats",

--- a/packages/terra-clinical-result/translations/fr.json
+++ b/packages/terra-clinical-result/translations/fr.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Erreur",
   "Terra.clinicalResult.statusInError": "En erreur",
   "Terra.clinicalResult.statusInErrorHiddenText": "Valeur archivée avec le statut En erreur ",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Saisie erronée du résultat {strikethroughResult}",
   "Terra.clinicalResult.selectToViewAria": "Sélectionnez pour afficher plus de détails.",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Le résultat inclut des valeurs supplémentaires.",
   "Terra.clinicalResult.viewResults": "Afficher les résultats",

--- a/packages/terra-clinical-result/translations/nl-BE.json
+++ b/packages/terra-clinical-result/translations/nl-BE.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Fout",
   "Terra.clinicalResult.statusInError": "Fout",
   "Terra.clinicalResult.statusInErrorHiddenText": "Geschrapt als Fout beschouwen",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Het resultaat {strikethroughResult} is per ongeluk ingevoerd",
   "Terra.clinicalResult.selectToViewAria": "Selecteer om meer details te bekijken",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Resultaat bevat aanvullende waarden",
   "Terra.clinicalResult.viewResults": "Resultaten weergeven",

--- a/packages/terra-clinical-result/translations/nl.json
+++ b/packages/terra-clinical-result/translations/nl.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Fout",
   "Terra.clinicalResult.statusInError": "Fout",
   "Terra.clinicalResult.statusInErrorHiddenText": "Geschrapt als Fout beschouwen",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Het resultaat {strikethroughResult} is per ongeluk ingevoerd",
   "Terra.clinicalResult.selectToViewAria": "Selecteer om meer details te bekijken",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Resultaat bevat aanvullende waarden",
   "Terra.clinicalResult.viewResults": "Resultaten weergeven",

--- a/packages/terra-clinical-result/translations/pt-BR.json
+++ b/packages/terra-clinical-result/translations/pt-BR.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Erro",
   "Terra.clinicalResult.statusInError": "Em erro",
   "Terra.clinicalResult.statusInErrorHiddenText": "Valor não documentado como Com erro",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultado {strikethroughResult} inserido Em erro",
   "Terra.clinicalResult.selectToViewAria": "Selecione para visualizar mais detalhes",
   "Terra.clinicalResult.includesAdditionalValuesAria": "O resultado inclui valores adicionais",
   "Terra.clinicalResult.viewResults": "Visualizar resultados",

--- a/packages/terra-clinical-result/translations/pt.json
+++ b/packages/terra-clinical-result/translations/pt.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Erro",
   "Terra.clinicalResult.statusInError": "Em erro",
   "Terra.clinicalResult.statusInErrorHiddenText": "Valor não documentado como Com erro",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultado {strikethroughResult} inserido Em erro",
   "Terra.clinicalResult.selectToViewAria": "Selecione para visualizar mais detalhes",
   "Terra.clinicalResult.includesAdditionalValuesAria": "O resultado inclui valores adicionais",
   "Terra.clinicalResult.viewResults": "Visualizar resultados",

--- a/packages/terra-clinical-result/translations/sv-SE.json
+++ b/packages/terra-clinical-result/translations/sv-SE.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Fel",
   "Terra.clinicalResult.statusInError": "Felaktig",
   "Terra.clinicalResult.statusInErrorHiddenText": "Värdet togs bort eftersom det var felaktigt",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultatet {strikethroughResult} har angetts felaktigt",
   "Terra.clinicalResult.selectToViewAria": "Välj för att visa fler uppgifter.",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Resultatet innehåller fler värden",
   "Terra.clinicalResult.viewResults": "Visa resultat",

--- a/packages/terra-clinical-result/translations/sv.json
+++ b/packages/terra-clinical-result/translations/sv.json
@@ -2,6 +2,7 @@
   "Terra.clinicalResult.resultError": "Fel",
   "Terra.clinicalResult.statusInError": "Felaktig",
   "Terra.clinicalResult.statusInErrorHiddenText": "Värdet togs bort eftersom det var felaktigt",
+  "Terra.clinicalResult.statusInErrorStrikethrough": "Resultatet {strikethroughResult} har angetts felaktigt",
   "Terra.clinicalResult.selectToViewAria": "Välj för att visa fler uppgifter.",
   "Terra.clinicalResult.includesAdditionalValuesAria": "Resultatet innehåller fler värden",
   "Terra.clinicalResult.viewResults": "Visa resultat",


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
When trying to validate the alt text for strikethroughs I see that the clinical result site page has an error message. In the dev tools I’m seeing the message “TypeError: Cannot read properties of undefined (reading 'unit')“

I believe my issue is a small check that differs between the clinical result display and the blood pressure display files.

You can see in the clinical result blood pressure display file I’m checking the unit is valid like so: https://github.com/cerner/terra-clinical/pull/870/files#diff-167a4e0b1d0ca2ee4064ed5b2c27e92feee651e13b3b21766c1ad4e538a18a77R48 

But I in the clinical result display file I didn’t use the optional chaining operator (?.): https://github.com/cerner/terra-clinical/pull/870/files#diff-7431c9460fef4d7dc39515e8a588b9374dfdf2c11c98373005aaf3e5e0b8bd3eR91 

So I went ahead and added it, 

**What was changed:**
Add optional chaining operator to clinical result display like it is in clinical result blood pressure display.

**Why it was changed:**
From my understanding - the ?. operator is like the . chaining operator, except that instead of causing an error if a reference is nullish (null or undefined), the expression short-circuits with a return value of undefined.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9067 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
