### PR TITLE
[terra-clinical-result] Remove <time> tags from ResultTimeHeaderCell

### DIFF
--- a/packages/terra-clinical-result/CHANGELOG.md
+++ b/packages/terra-clinical-result/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Changed ResultTimeHeaderCell to remove the `<time>` html tag for the date and time. This was causing issues and technically does not have full screen reader support.
+
 ## 1.18.0 - (June 22, 2023)
 
 * Added

--- a/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
+++ b/packages/terra-clinical-result/src/result-time-header-cell/ResultTimeHeaderCell.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import classNamesBind from 'classnames/bind';
 import ThemeContext from 'terra-theme-context';
-import VisuallyHiddenText from 'terra-visually-hidden-text';
 import styles from './ResultTimeHeaderCell.module.scss';
 
 const cx = classNamesBind.bind(styles);
@@ -62,9 +61,8 @@ const ResultTimeHeaderCell = (props) => {
       {...customProps}
       className={timeHeaderCellClassnames}
     >
-      <time className={dateClassnames}>{date}</time>
-      <VisuallyHiddenText text={'\u00A0'} />
-      <time className={cx('time')}>{time}</time>
+      <div className={dateClassnames}>{date}</div>
+      <div className={cx('time')}>{time}</div>
     </th>
   );
 };

--- a/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
+++ b/packages/terra-clinical-result/tests/jest/result-time-header-cell/__snapshots__/ResultTimeHeaderCell.test.jsx.snap
@@ -4,19 +4,16 @@ exports[`ResultTimeHeaderCell correctly applies the theme context className 1`] 
 <th
   className="clinical-result-time-header-cell padding-compact orion-fusion-theme"
 >
-  <time
+  <div
     className="date"
   >
     December 31st 1999
-  </time>
-  <VisuallyHiddenText
-    text=" "
-  />
-  <time
+  </div>
+  <div
     className="time"
   >
     10:00 PM
-  </time>
+  </div>
 </th>
 `;
 
@@ -24,19 +21,16 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with compact 1`] = `
 <th
   className="clinical-result-time-header-cell padding-compact"
 >
-  <time
+  <div
     className="date"
   >
     December 31st 1999
-  </time>
-  <VisuallyHiddenText
-    text=" "
-  />
-  <time
+  </div>
+  <div
     className="time"
   >
     10:00 PM
-  </time>
+  </div>
 </th>
 `;
 
@@ -44,19 +38,16 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with none 1`] = `
 <th
   className="clinical-result-time-header-cell"
 >
-  <time
+  <div
     className="date"
   >
     December 31st 1999
-  </time>
-  <VisuallyHiddenText
-    text=" "
-  />
-  <time
+  </div>
+  <div
     className="time"
   >
     10:00 PM
-  </time>
+  </div>
 </th>
 `;
 
@@ -64,19 +55,16 @@ exports[`ResultTimeHeaderCell paddingStyle - should render with standard 1`] = `
 <th
   className="clinical-result-time-header-cell padding-standard"
 >
-  <time
+  <div
     className="date"
   >
     December 31st 1999
-  </time>
-  <VisuallyHiddenText
-    text=" "
-  />
-  <time
+  </div>
+  <div
     className="time"
   >
     10:00 PM
-  </time>
+  </div>
 </th>
 `;
 
@@ -84,19 +72,16 @@ exports[`ResultTimeHeaderCell should hide date 1`] = `
 <th
   className="clinical-result-time-header-cell padding-compact"
 >
-  <time
+  <div
     className="date hide-date"
   >
     December 31st 1999
-  </time>
-  <VisuallyHiddenText
-    text=" "
-  />
-  <time
+  </div>
+  <div
     className="time"
   >
     10:00 PM
-  </time>
+  </div>
 </th>
 `;
 
@@ -104,18 +89,15 @@ exports[`ResultTimeHeaderCell should render a date and time 1`] = `
 <th
   className="clinical-result-time-header-cell padding-compact"
 >
-  <time
+  <div
     className="date"
   >
     December 31st 1999
-  </time>
-  <VisuallyHiddenText
-    text=" "
-  />
-  <time
+  </div>
+  <div
     className="time"
   >
     10:00 PM
-  </time>
+  </div>
 </th>
 `;


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
When merging changes for the most recent release two of our PRs didn't play together properly and it was missed. We are seeing some issues with spacing in the ResultTimeHeaderCell component. When in a semantic table the time and date are squished together instead of being on separate newlines. This only effects the semantic examples. 

Issue with semantic table:
<img width="969" alt="Screenshot 2023-06-26 at 11 13 52 AM" src="https://github.com/cerner/terra-clinical/assets/40574651/3ec40473-f749-4b69-8591-602586f7bb04">

Looks fine in non-semantic example:
<img width="969" alt="Screenshot 2023-06-26 at 11 14 39 AM" src="https://github.com/cerner/terra-clinical/assets/40574651/42893cb6-90d4-4542-92b8-098bb06d1841">

Update: This lead us to seeing several different issues with how the time tag is working. After a long discussion we have decided to remove it entirely.

**What was changed:**
Change the time tags back to divs, also remove the hidden text between the two.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-XXXX <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra

Validation:

Non-semantic 

https://github.com/cerner/terra-clinical/assets/40574651/1d5c349f-3e78-4494-830b-356ae9bc5dd4



Semantic table

https://github.com/cerner/terra-clinical/assets/40574651/68dfde7b-5e04-4c9d-ada3-06d1c6ecad5d

