### PR TITLE
[terra-clinical-detail-view] Update Detail List to accept null as children

### DIFF
--- a/packages/terra-clinical-detail-view/CHANGELOG.md
+++ b/packages/terra-clinical-detail-view/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Update Detail List to accept null as children
+
 ## 3.31.0 - (June 22, 2023)
 
 * Added

--- a/packages/terra-clinical-detail-view/src/DetailList.jsx
+++ b/packages/terra-clinical-detail-view/src/DetailList.jsx
@@ -56,9 +56,11 @@ const DetailList = ({
     : (
       <ul className={cx('list')}>
         {Children.map(children, child => (
-          <li key={child.id} className={cx('list-item')}>
-            {child}
-          </li>
+          child ? (
+            <li key={child.id} className={cx('list-item')}>
+              {child}
+            </li>
+          ) : null
         ))}
       </ul>
     );

--- a/packages/terra-clinical-detail-view/src/terra-dev-site/test/clinical-detail-view/DetailList/LargeItemList.test.jsx
+++ b/packages/terra-clinical-detail-view/src/terra-dev-site/test/clinical-detail-view/DetailList/LargeItemList.test.jsx
@@ -10,6 +10,7 @@ const DefaultDetailList = () => (
     <DetailView.DetailListItem item={item} />
     <DetailView.DetailListItem item={item} />
     <DetailView.DetailListItem item={item2} />
+    {null}
     <DetailView.DetailListItem item={item} />
     <DetailView.DetailListItem item={item} />
   </DetailView.DetailList>

--- a/packages/terra-clinical-detail-view/tests/jest/DetailList.test.jsx
+++ b/packages/terra-clinical-detail-view/tests/jest/DetailList.test.jsx
@@ -31,6 +31,17 @@ it('should render a list', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it('should render a list when null is passed', () => {
+  const detailList = (
+    <DetailView.DetailList>
+      <DetailView.DetailListItem item={<p>Test</p>} />
+      {null}
+    </DetailView.DetailList>
+  );
+  const wrapper = render(detailList);
+  expect(wrapper).toMatchSnapshot();
+});
+
 it('should render a title and a list', () => {
   const wrapper = render(defaultVariety);
   expect(wrapper).toMatchSnapshot();

--- a/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailList.test.jsx.snap
+++ b/packages/terra-clinical-detail-view/tests/jest/__snapshots__/DetailList.test.jsx.snap
@@ -64,6 +64,28 @@ exports[`should render a list 1`] = `
 </div>
 `;
 
+exports[`should render a list when null is passed 1`] = `
+<div
+  data-terra-clinical-detail-list="true"
+>
+  <ul
+    class="list"
+  >
+    <li
+      class="list-item"
+    >
+      <div
+        class="detail-list-item"
+      >
+        <p>
+          Test
+        </p>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`should render a title 1`] = `
 <div
   data-terra-clinical-detail-list="true"


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->
Updated Detail List to accept null as children

**What was changed:**
When creating an unordered list, we access the child's id. If null is passed, then the component throws an error. Now we check if the child exists before returning the `li` element.

**Why it was changed:**
When null is passed as a child, the component shouldn't throw an error. 


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [x] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-9223

---

Thank you for contributing to Terra.
@cerner/terra
