### PR TITLE
jest.mock replaced with jest.spyOn

### DIFF
--- a/packages/terra-clinical-detail-view/src/terra-dev-site/doc/clinical-detail-view/ClinicalDetailView.1.doc.mdx
+++ b/packages/terra-clinical-detail-view/src/terra-dev-site/doc/clinical-detail-view/ClinicalDetailView.1.doc.mdx
@@ -62,7 +62,7 @@ let mockSpyUuid;
 
 // using a variable may result in failures. For best results, mock return value.
 beforeAll(() => {
-  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
 });
 
 // restore the mock

--- a/packages/terra-clinical-detail-view/src/terra-dev-site/doc/clinical-detail-view/ClinicalDetailView.1.doc.mdx
+++ b/packages/terra-clinical-detail-view/src/terra-dev-site/doc/clinical-detail-view/ClinicalDetailView.1.doc.mdx
@@ -51,11 +51,23 @@ import DetailView from 'terra-clinical-detail-view';
 
 ## Testing
 
-Menu uses `uuid` which changes the component's description id dynamically. To mock it with the Jest testing library, `jest.mock` can be used.
+Menu uses `uuid` which changes the component's description id dynamically. To mock the return value with the Jest testing library, `jest.spyOn` can be used.
 
 If Enzyme `shallow` rendering is being used for the tests then the mock may not be required. However, if `mount` is used then `uuid` should be mocked as shown below:
 
 ```js
-// using a variable may result in failures. For best results, hardcode the mock return value.
-jest.mock('uuid', () => ({ v4: () => '00000000-0000-0000-0000-000000000000' }));
+import { v4 as uuidv4 } from 'uuid';
+
+let mockSpyUuid;
+
+// using a variable may result in failures. For best results, mock return value.
+beforeAll(() => {
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+});
+
+// restore the mock
+afterAll(() => {
+  mockSpyUuid.mockRestore();
+});
+
 ```

--- a/packages/terra-clinical-detail-view/tests/jest/DetailList.test.jsx
+++ b/packages/terra-clinical-detail-view/tests/jest/DetailList.test.jsx
@@ -6,7 +6,7 @@ import DetailView from '../../src/DetailView';
 let mockSpyUuid;
 
 beforeAll(() => {
-  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
 });
 
 afterAll(() => {

--- a/packages/terra-clinical-detail-view/tests/jest/DetailList.test.jsx
+++ b/packages/terra-clinical-detail-view/tests/jest/DetailList.test.jsx
@@ -1,7 +1,17 @@
 import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { v4 as uuidv4 } from 'uuid';
 import DetailView from '../../src/DetailView';
 
-jest.mock('uuid', () => ({ v4: () => '00000000-0000-0000-0000-000000000000' }));
+let mockSpyUuid;
+
+beforeAll(() => {
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+});
+
+afterAll(() => {
+  mockSpyUuid.mockRestore();
+});
 
 const defaultVariety = (
   <DetailView.DetailList title="Title">

--- a/packages/terra-clinical-detail-view/tests/jest/DetailView.test.jsx
+++ b/packages/terra-clinical-detail-view/tests/jest/DetailView.test.jsx
@@ -6,7 +6,7 @@ import DetailView from '../../src/DetailView';
 let mockSpyUuid;
 
 beforeAll(() => {
-  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
 });
 
 afterAll(() => {

--- a/packages/terra-clinical-detail-view/tests/jest/DetailView.test.jsx
+++ b/packages/terra-clinical-detail-view/tests/jest/DetailView.test.jsx
@@ -1,7 +1,17 @@
 import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { v4 as uuidv4 } from 'uuid';
 import DetailView from '../../src/DetailView';
 
-jest.mock('uuid', () => ({ v4: () => '00000000-0000-0000-0000-000000000000' }));
+let mockSpyUuid;
+
+beforeAll(() => {
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+});
+
+afterAll(() => {
+  mockSpyUuid.mockRestore();
+});
 
 const defaultVariety = <DetailView />;
 

--- a/packages/terra-clinical-result/CHANGELOG.md
+++ b/packages/terra-clinical-result/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Fixed
   * Fixed infinite re-render bug.
 
+* Changed
+  * Updated testing recommendations to use `jest.spyOn` instead of `jest.mock`.
+
 ## 1.21.0 - (August 2, 2023)
 
 * Changed

--- a/packages/terra-clinical-result/src/ClinicalResultBloodPressure.jsx
+++ b/packages/terra-clinical-result/src/ClinicalResultBloodPressure.jsx
@@ -91,8 +91,7 @@ const createConceptDisplays = (compareConceptDisplays) => {
   return null;
 };
 
-const idForDatetimeDisplays = `${uuidv4()}-datetimeDisplay`;
-const createDatetimeDisplays = (compareDatetimeDisplays) => {
+const createDatetimeDisplays = (compareDatetimeDisplays, idForDatetimeDisplays) => {
   if (compareDatetimeDisplays.systolic && compareDatetimeDisplays.diastolic) {
     if (compareDatetimeDisplays.systolic === compareDatetimeDisplays.diastolic) {
       return <div className={cx('datetime-display')} id={idForDatetimeDisplays}>{compareDatetimeDisplays.originalSystolic}</div>;
@@ -145,12 +144,13 @@ const ClinicalResultBloodPressure = (props) => {
     diastolic: diastolicResult.cleanedConceptDisplay,
   });
 
+  const idForDatetimeDisplays = `${uuidv4()}-datetimeDisplay`;
   const datetimeDisplayElement = createDatetimeDisplays({
     originalSystolic: systolicResult.datetimeDisplay,
     originalDiastolic: diastolicResult.datetimeDisplay,
     systolic: systolicResult.cleanedDatetimeDisplay,
     diastolic: diastolicResult.cleanedDatetimeDisplay,
-  });
+  }, idForDatetimeDisplays);
 
   const hasModifiedIcon = (systolicResult.isModified) || (diastolicResult.isModified);
   const hasCommentIcon = (systolicResult.hasComment) || (diastolicResult.hasComment);

--- a/packages/terra-clinical-result/src/terra-dev-site/doc/ClinicalResult/ClinicalResult.1.doc.mdx
+++ b/packages/terra-clinical-result/src/terra-dev-site/doc/ClinicalResult/ClinicalResult.1.doc.mdx
@@ -76,11 +76,22 @@ import ClinicalResult from 'terra-clinical-result/lib/index';
 
 ## Testing
 
-Menu uses `uuid` which changes the component's description id dynamically. To mock it with the Jest testing library, `jest.mock` can be used.
+Menu uses `uuid` which changes the component's description id dynamically. To mock the return value with the Jest testing library, `jest.spyOn` can be used.
 
 If Enzyme `shallow` rendering is being used for the tests then the mock may not be required. However, if `mount` is used then `uuid` should be mocked as shown below:
 
 ```js
-// using a variable may result in failures. For best results, hardcode the mock return value.
-jest.mock('uuid', () => ({ v4: () => '00000000-0000-0000-0000-000000000000' }));
+import { v4 as uuidv4 } from 'uuid';
+
+let mockSpyUuid;
+
+// using a variable may result in failures. For best results, mock return value.
+beforeAll(() => {
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+});
+
+// restore the mock
+afterAll(() => {
+  mockSpyUuid.mockRestore();
+});
 ```

--- a/packages/terra-clinical-result/src/terra-dev-site/doc/ClinicalResult/ClinicalResult.1.doc.mdx
+++ b/packages/terra-clinical-result/src/terra-dev-site/doc/ClinicalResult/ClinicalResult.1.doc.mdx
@@ -87,7 +87,7 @@ let mockSpyUuid;
 
 // using a variable may result in failures. For best results, mock return value.
 beforeAll(() => {
-  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+  mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
 });
 
 // restore the mock

--- a/packages/terra-clinical-result/tests/jest/ClinicalResultBloodPressure.test.jsx
+++ b/packages/terra-clinical-result/tests/jest/ClinicalResultBloodPressure.test.jsx
@@ -17,7 +17,7 @@ describe('ClinicalResultBloodPressure', () => {
   let idForDatetimeDisplays;
 
   beforeAll(() => {
-    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
     idForDatetimeDisplays = `${uuidv4()}-datetimeDisplay`;
   });
 

--- a/packages/terra-clinical-result/tests/jest/ClinicalResultBloodPressure.test.jsx
+++ b/packages/terra-clinical-result/tests/jest/ClinicalResultBloodPressure.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import { shallowWithIntl } from 'terra-enzyme-intl';
+import { v4 as uuidv4 } from 'uuid';
 import ClinicalResultBloodPressure from '../../src/ClinicalResultBloodPressure';
 import {
   DefaultBloodPressureResult,
@@ -10,9 +11,20 @@ import {
   NoDataResult,
 } from '../../src/terra-dev-site/test/clinical-result/TestResults';
 
-jest.mock('uuid', () => ({ v4: () => '00000000-0000-0000-0000-000000000000' }));
-
 describe('ClinicalResultBloodPressure', () => {
+  let mockSpyUuid;
+  // eslint-disable-next-line no-unused-vars
+  let idForDatetimeDisplays;
+
+  beforeAll(() => {
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => '00000000-0000-0000-0000-000000000000');
+    idForDatetimeDisplays = `${uuidv4()}-datetimeDisplay`;
+  });
+
+  afterAll(() => {
+    mockSpyUuid.mockRestore();
+  });
+
   it('should render a ResultError if hasResultError is true', () => {
     const result = shallowWithIntl(<ClinicalResultBloodPressure hasResultError />).dive();
     expect(result).toMatchSnapshot();


### PR DESCRIPTION
### Summary
Currently the uuid test mocks are hard coded. In order to ensures that every test is fresh and independent of each other, the proposed solution was to use beforeAll() to set up the mock. As jest.mock can't be used inside of the tests or inside beforeAll, jest.spyOn was used instead of jest.mock.

**What was changed:**

1. Hard-coded jest.mock were replaced with jest.spyOn inside the beforeAll().
2. The mocks were restored in afterAll().
3. The testing section in documentation was updated to reflect the suggested testing method.

### Testing
This change was tested using:

- [x] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
**This PR is a part of following JIRA:**
UXPLATFORM-9515