### PR TITLE
[terra-clinical-header] Wrapped start and end content

### DIFF
--- a/packages/terra-clinical-header/CHANGELOG.md
+++ b/packages/terra-clinical-header/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Changed styles to allow wrapping o start and end content.
+
 ## 3.30.0 - (March 1, 2024)
 
 * Changed

--- a/packages/terra-clinical-header/CHANGELOG.md
+++ b/packages/terra-clinical-header/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Changed
-  * Changed styles to allow wrapping o start and end content.
+  * Changed styles to allow wrapping of start and end content.
 
 ## 3.30.0 - (March 1, 2024)
 

--- a/packages/terra-clinical-header/src/Header.jsx
+++ b/packages/terra-clinical-header/src/Header.jsx
@@ -133,12 +133,16 @@ const Header = ({
     customProps.className,
   ]);
 
+  const renderTitle = !(!titleContent && startContent && endContent);
+
   return (
     <header {...customProps} className={headerClassNames}>
       {startContent && <div className={cx('flex-end')}>{startContent}</div>}
+      {renderTitle && (
       <div className={cx('flex-fill')}>
         {titleElement}
       </div>
+      )}
       {content}
       {endContent && <div className={cx('flex-end')}>{endContent}</div>}
     </header>

--- a/packages/terra-clinical-header/src/Header.module.scss
+++ b/packages/terra-clinical-header/src/Header.module.scss
@@ -39,8 +39,10 @@
 
   .flex-end {
     display: flex;
-    flex: 0 0 auto;
-    position: relative;
+    flex-flow: column wrap;
+    justify-content: flex-start;
+    align-items: flex-start;
+    align-content: flex-start;
   }
 
   .title-container {

--- a/packages/terra-clinical-header/tests/jest/Header.test.jsx
+++ b/packages/terra-clinical-header/tests/jest/Header.test.jsx
@@ -91,6 +91,23 @@ it('should render a header with all content', () => {
   expect(header).toMatchSnapshot();
 });
 
+it('should render a header with start and end content and no title', () => {
+  const startContent = <div id="start-id">start content</div>;
+  const endContent = <div id="end-id">end content</div>;
+  const flexEndStart = <div className="flex-end">{startContent}</div>;
+  const flexEndEnd = <div className="flex-end">{endContent}</div>;
+  const header = shallow((
+    <Header
+      startContent={startContent}
+      endContent={endContent}
+    />
+  ));
+
+  expect(header.find('.flex-header').props().children[0]).toEqual(flexEndStart);
+  expect(header.find('.flex-header').props().children[3]).toEqual(flexEndEnd);
+  expect(header).toMatchSnapshot();
+});
+
 it('should render a subheader with title and heading level', () => {
   const consoleSpy = jest.spyOn(global.console, 'warn');
   const subheader = shallow(<Header title="title" isSubheader />);

--- a/packages/terra-clinical-header/tests/jest/__snapshots__/Header.test.jsx.snap
+++ b/packages/terra-clinical-header/tests/jest/__snapshots__/Header.test.jsx.snap
@@ -197,6 +197,31 @@ exports[`should render a header with id 1`] = `
 </header>
 `;
 
+exports[`should render a header with start and end content and no title 1`] = `
+<header
+  className="flex-header"
+>
+  <div
+    className="flex-end"
+  >
+    <div
+      id="start-id"
+    >
+      start content
+    </div>
+  </div>
+  <div
+    className="flex-end"
+  >
+    <div
+      id="end-id"
+    >
+      end content
+    </div>
+  </div>
+</header>
+`;
+
 exports[`should render a header with title 1`] = `
 <header
   className="flex-header"


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Added flex wrap to start and end content.

**Why it was changed:**
MPages require the content of clinical header to wrap instead of scroll.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10197 <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
