### PR TITLE
renamed year select min-width css variable

### DIFF
--- a/packages/terra-clinical-onset-picker/CHANGELOG.md
+++ b/packages/terra-clinical-onset-picker/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Renamed year select min-width css variable for the fusion theme to not be overridden by the same name variable coming from deprecated orion-fusion-theme package.
+
 ## 4.39.0 - (April 2, 2024)
 
 * Changed

--- a/packages/terra-clinical-onset-picker/src/OnsetPicker.module.scss
+++ b/packages/terra-clinical-onset-picker/src/OnsetPicker.module.scss
@@ -46,6 +46,6 @@
   }
 
   .year {
-    min-width: var(--terra-clinical-onset-picker-year-select-min-width, 5.5em);
+    min-width: var(--terra-clinical-onset-picker-calendar-year-select-min-width, 5.5em);
   }
 }

--- a/packages/terra-clinical-onset-picker/src/clinical-lowlight-theme/OnsetPicker.module.scss
+++ b/packages/terra-clinical-onset-picker/src/clinical-lowlight-theme/OnsetPicker.module.scss
@@ -7,6 +7,6 @@
     --terra-clinical-onset-picker-granularity-select-min-width: 7em;
     --terra-clinical-onset-picker-month-select-min-width: 10.5em;
     --terra-clinical-onset-picker-age-granularity-select-min-width: 7em;
-    --terra-clinical-onset-picker-year-select-min-width: 5.5em;
+    --terra-clinical-onset-picker-calendar-year-select-min-width: 5.5em;
   }
 }

--- a/packages/terra-clinical-onset-picker/src/orion-fusion-theme/OnsetPicker.module.scss
+++ b/packages/terra-clinical-onset-picker/src/orion-fusion-theme/OnsetPicker.module.scss
@@ -7,6 +7,6 @@
     --terra-clinical-onset-picker-granularity-select-min-width: 8rem;
     --terra-clinical-onset-picker-month-select-min-width: 10rem;
     --terra-clinical-onset-picker-age-granularity-select-min-width: 8rem;
-    --terra-clinical-onset-picker-year-select-min-width: 6rem;
+    --terra-clinical-onset-picker-calendar-year-select-min-width: 6rem;
   }
 }


### PR DESCRIPTION
### Summary

It has been reported, that the value of the **--terra-clinical-onset-picker-year-select-min-width** variable in fusion theme is can be overridden by the same name variable coming from deprecated **orion-fusion-theme** package, which sometimes appears as dependency in some projects. To avoid that, the variable was renamed to --terra-clinical-onset-picker**-calendar**-year-select-min-width.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [x] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

The new variable being populated instead of the old one:
<img width="575" alt="Screenshot 2024-04-11 at 2 25 27 PM" src="https://github.com/cerner/terra-clinical/assets/119358186/b5b19975-dd64-4f30-a9db-e394ae20c393">

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-10364
